### PR TITLE
Adding client side timeout options for queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ macro_rules! row {
     };
 }
 
+#[macro_export]
 macro_rules! try_opt {
     ($expr:expr) => {
         match $expr {

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -467,4 +467,19 @@ mod test {
 
         run(done).unwrap();
     }
+
+    #[test]
+    fn test_query_timeout() {
+        let test_db_url = format!("{}{}", DATABASE_URL.as_str(), "&query_timeout=10ms");
+        let pool = Pool::new(test_db_url.to_string());
+
+        let done = pool.get_handle()
+            .and_then(|c| c.query("SELECT sleep(1)").fetch_all());
+
+
+        run(done).unwrap_err();
+
+        let info = pool.info();
+        assert_eq!(info.ongoing, 0);
+    }
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -470,11 +470,11 @@ mod test {
 
     #[test]
     fn test_query_timeout() {
-        let test_db_url = format!("{}{}", DATABASE_URL.as_str(), "&query_timeout=10ms");
+        let test_db_url = format!("{}{}", DATABASE_URL.as_str(), "&query_timeout=5ms");
         let pool = Pool::new(test_db_url.to_string());
 
         let done = pool.get_handle()
-            .and_then(|c| c.query("SELECT sleep(1)").fetch_all());
+            .and_then(|c| c.query("SELECT sleep(10)").fetch_all());
 
 
         run(done).unwrap_err();

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -168,10 +168,10 @@ pub struct Options {
     /// Timeout for connection (defaults to `500 ms`)
     pub(crate) connection_timeout: Duration,
 
-    /// Timeout for queries (defaults to `1800000 ms`)
+    /// Timeout for queries (defaults to `180,000 ms`)
     pub(crate) query_timeout: Duration,
 
-    /// Timeout for each block in a query (defaults to `180000 ms`)
+    /// Timeout for each block in a query (defaults to `180,000 ms`)
     pub(crate) query_block_timeout: Duration,
 }
 
@@ -192,8 +192,8 @@ impl Default for Options {
             retry_timeout: Duration::from_secs(5),
             ping_timeout: Duration::from_millis(500),
             connection_timeout: Duration::from_millis(500),
-            query_timeout: Duration::from_millis(180000),
-            query_block_timeout: Duration::from_millis(180000),
+            query_timeout: Duration::from_millis(180_000),
+            query_block_timeout: Duration::from_millis(180_000),
         }
     }
 }

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -167,6 +167,12 @@ pub struct Options {
 
     /// Timeout for connection (defaults to `500 ms`)
     pub(crate) connection_timeout: Duration,
+
+    /// Timeout for queries (defaults to `1800000 ms`)
+    pub(crate) query_timeout: Duration,
+
+    /// Timeout for each block in a query (defaults to `180000 ms`)
+    pub(crate) query_block_timeout: Duration,
 }
 
 impl Default for Options {
@@ -186,6 +192,8 @@ impl Default for Options {
             retry_timeout: Duration::from_secs(5),
             ping_timeout: Duration::from_millis(500),
             connection_timeout: Duration::from_millis(500),
+            query_timeout: Duration::from_millis(180000),
+            query_block_timeout: Duration::from_millis(180000),
         }
     }
 }
@@ -289,6 +297,16 @@ impl Options {
         /// Timeout for connection (defaults to `500 ms`).
         => connection_timeout: Duration
     }
+
+    property! {
+        /// Timeout for query (defaults to `180,000 ms`).
+        => query_timeout: Duration
+    }
+
+    property! {
+        /// Timeout for each block in a query (defaults to `180,000 ms`).
+        => query_block_timeout: Duration
+    }
 }
 
 impl FromStr for Options {
@@ -357,7 +375,13 @@ where
             "ping_timeout" => options.ping_timeout = parse_param(key, value, parse_duration)?,
             "connection_timeout" => {
                 options.connection_timeout = parse_param(key, value, parse_duration)?
-            }
+            },
+            "query_timeout" => {
+                options.query_timeout = parse_param(key, value, parse_duration)?
+            },
+            "query_block_timeout" => {
+                options.query_block_timeout = parse_param(key, value, parse_duration)?
+            },
             "compression" => options.compression = parse_param(key, value, parse_compression)?,
             _ => return Err(UrlError::UnknownParameter { param: key.into() }),
         };


### PR DESCRIPTION
This PR is meant to add options to allow users of clickhouse-rs to set timeout durations for overall query time and query block stream times. 

@suharev7 thank you for the initial pointers and please feel free to let me know what you think. Also thanks to @hwchen for collaborating on this!