### PR TITLE
Expose GetHandle future

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,8 @@ mod connecting_stream;
 /// Error types.
 pub mod errors;
 mod io;
-mod pool;
+/// Pool types.
+pub mod pool;
 mod retry_guard;
 /// Clickhouse types.
 pub mod types;

--- a/src/pool/futures/get_handle.rs
+++ b/src/pool/futures/get_handle.rs
@@ -6,6 +6,7 @@ use pin_project::pin_project;
 
 use crate::{errors::Result, pool::Pool, ClientHandle};
 
+/// Future that resolves to a `ClientHandle`.
 #[pin_project]
 pub struct GetHandle {
     #[pin]
@@ -13,7 +14,7 @@ pub struct GetHandle {
 }
 
 impl GetHandle {
-    pub fn new(pool: &Pool) -> Self {
+    pub(crate) fn new(pool: &Pool) -> Self {
         Self { pool: pool.clone() }
     }
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -12,9 +12,10 @@ use tokio::prelude::*;
 use crate::{
     Client,
     ClientHandle,
-    errors::Result,
-    pool::futures::GetHandle, types::{IntoOptions, OptionsSource},
+    errors::Result, types::{IntoOptions, OptionsSource},
 };
+
+pub use self::futures::GetHandle;
 
 mod futures;
 


### PR DESCRIPTION
Required if you want to create non-dyn/boxed futures that depend on a client handle future.