### PR TITLE
Upgrade to tokio 0.2.0 and futures-* 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,34 +20,55 @@ async_std = ["async-std"]
 tokio_io = ["tokio"]
 
 [dependencies]
-futures-core-preview = "=0.3.0-alpha.19"
-futures-sink-preview = "=0.3.0-alpha.19"
-futures-util-preview = { version = "=0.3.0-alpha.19", features = ["sink"] }
-
-tokio = { version = "0.2.0-alpha.6", default-features = false, features = ["io", "net", "sync", "rt-full"], optional = true }
-async-std = { version = "0.99.11", optional = true }
-pin-project = "0.4.5"
-
-hostname = "^0.1"
-
+byteorder = "^1.3"
 chrono = "0.4"
 chrono-tz = "0.5"
-
-lz4 = "1.23.1"
-clickhouse-rs-cityhash-sys = { path = "clickhouse-rs-cityhash-sys", version = "0.1.1" }
-
-byteorder = "^1.3"
+crossbeam = "0.7"
 failure = "^0.1.5"
 failure_derive = "^0.1.5"
-url="^2"
+futures-core = "0.3.0"
+futures-sink = "0.3.0"
+hostname = "^0.1"
 lazy_static = "1.4.0"
+lz4 = "1.23.1"
+pin-project = "0.4.5"
+url="^2"
 
-log = { version = "0.4.8", features = ["std", "serde"] }
-crossbeam = "0.7"
+[dependencies.futures-util]
+version = "0.3.0"
+features = ["sink"]
 
-native-tls = { version = "0.2", optional = true }
-tokio-tls = { version = "=0.3.0-alpha.6", optional = true }
+[dependencies.tokio]
+version = "0.2.0"
+default-features = false
+features = ["io-util", "time", "net", "sync", "rt-threaded"]
+optional = true
+
+[dependencies.async-std]
+version = "0.99.11"
+optional = true
+
+[dependencies.clickhouse-rs-cityhash-sys]
+path = "clickhouse-rs-cityhash-sys"
+version = "0.1.1"
+
+[dependencies.log]
+version = "0.4.8"
+features = ["std", "serde"]
+
+[dependencies.native-tls]
+version = "0.2"
+optional = true
+
+[dependencies.tokio-tls]
+version = "0.3.0"
+optional = true
 
 [dev-dependencies]
 env_logger = "^0.6"
 rand = "^0.7"
+
+[dev-dependencies.tokio]
+version = "0.2.0"
+default-features = false
+features = ["macros"]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
-use std::{env, error::Error};
 use clickhouse_rs::{row, types::Block, Pool};
 use futures_util::StreamExt;
+use std::{env, error::Error};
 
 async fn execute(database_url: String) -> Result<(), Box<dyn Error>> {
     env::set_var("RUST_LOG", "clickhouse_rs=debug");
@@ -49,9 +49,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(all(feature = "tokio_io", feature = "tls"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| {
-        "tcp://localhost:9440?secure=true&skip_verify=true".into()
-    });
+    let database_url = env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "tcp://localhost:9440?secure=true&skip_verify=true".into());
     execute(database_url).await
 }
 

--- a/src/connecting_stream.rs
+++ b/src/connecting_stream.rs
@@ -8,14 +8,17 @@ use std::{
 use futures_core::future::BoxFuture;
 #[cfg(feature = "tls")]
 use futures_util::FutureExt;
-use futures_util::{try_future::{select_ok, SelectOk}, TryFutureExt};
+use futures_util::{
+    future::{select_ok, SelectOk},
+    TryFutureExt,
+};
 
+#[cfg(feature = "async_std")]
+use async_std::net::TcpStream;
 #[cfg(feature = "tls")]
 use native_tls::TlsConnector;
 #[cfg(feature = "tokio_io")]
 use tokio::net::TcpStream;
-#[cfg(feature = "async_std")]
-use async_std::net::TcpStream;
 
 use pin_project::{pin_project, project};
 use url::Url;
@@ -58,9 +61,7 @@ impl TcpState {
                 Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
                 Poll::Pending => Poll::Pending,
             },
-            TcpState::Fail(ref mut err) => {
-                Poll::Ready(Err(err.take().unwrap()))
-            },
+            TcpState::Fail(ref mut err) => Poll::Ready(Err(err.take().unwrap())),
         }
     }
 }
@@ -79,7 +80,7 @@ impl TlsState {
             TlsState::Fail(ref mut err) => {
                 let e = err.take().unwrap();
                 Poll::Ready(Err(e))
-            },
+            }
         }
     }
 }
@@ -164,12 +165,14 @@ impl ConnectingStream {
     }
 
     #[cfg(feature = "tls")]
-    fn new_tls_connection(addr: &Url, socket: SelectOk<ConnectingFuture<TcpStream>>, options: &Options) -> Self {
+    fn new_tls_connection(
+        addr: &Url,
+        socket: SelectOk<ConnectingFuture<TcpStream>>,
+        options: &Options,
+    ) -> Self {
         match addr.host_str().map(|host| host.to_owned()) {
-            None => {
-                Self {
-                    state: State::tls_host_err(),
-                }
+            None => Self {
+                state: State::tls_host_err(),
             },
             Some(host) => {
                 let mut builder = TlsConnector::builder();
@@ -180,18 +183,16 @@ impl ConnectingStream {
                 }
 
                 Self {
-                    state: State::tls_wait(
-                        Box::pin(async move {
-                            let (s, _) = socket.await?;
+                    state: State::tls_wait(Box::pin(async move {
+                        let (s, _) = socket.await?;
 
-                            let cx = builder.build()?;
-                            let cx = tokio_tls::TlsConnector::from(cx);
+                        let cx = builder.build()?;
+                        let cx = tokio_tls::TlsConnector::from(cx);
 
-                            Ok(cx.connect(&host, s).await?)
-                        })
-                    )
+                        Ok(cx.connect(&host, s).await?)
+                    })),
                 }
-            },
+            }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, io, result, str::Utf8Error, string::FromUtf8Error};
 
 use failure::*;
 #[cfg(feature = "tokio_io")]
-use tokio::timer::timeout::Elapsed;
+use tokio::time::Elapsed;
 use url::ParseError;
 
 /// Result type alias for this library.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,8 +1,5 @@
-pub(crate) use self::{
-    stream::Stream,
-    transport::ClickhouseTransport,
-};
+pub(crate) use self::{stream::Stream, transport::ClickhouseTransport};
 
 mod read_to_end;
-pub(crate) mod transport;
 pub(crate) mod stream;
+pub(crate) mod transport;

--- a/src/io/read_to_end.rs
+++ b/src/io/read_to_end.rs
@@ -6,9 +6,7 @@ use std::{
 
 use futures_core::ready;
 
-use crate::{
-    io::Stream as InnerStream,
-};
+use crate::io::Stream as InnerStream;
 
 struct Guard<'a> {
     buf: &'a mut Vec<u8>,

--- a/src/io/stream.rs
+++ b/src/io/stream.rs
@@ -1,8 +1,8 @@
 use std::{
     io,
-    time::Duration,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 #[cfg(feature = "tokio_io")]
@@ -10,13 +10,13 @@ use tokio::net::TcpStream;
 #[cfg(feature = "tls")]
 use tokio_tls::TlsStream;
 
-#[cfg(feature = "tokio_io")]
-use tokio::prelude::*;
-use pin_project::{pin_project, project};
-#[cfg(feature = "async_std")]
-use async_std::net::TcpStream;
 #[cfg(feature = "async_std")]
 use async_std::io::prelude::*;
+#[cfg(feature = "async_std")]
+use async_std::net::TcpStream;
+use pin_project::{pin_project, project};
+#[cfg(feature = "tokio_io")]
+use tokio::prelude::*;
 
 #[cfg(all(feature = "tls", feature = "tokio_io"))]
 type SecureTcpStream = TlsStream<TcpStream>;
@@ -68,7 +68,11 @@ impl Stream {
     }
 
     #[project]
-    pub(crate) fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+    pub(crate) fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
         #[project]
         match self.project() {
             Stream::Plain(stream) => stream.poll_read(cx, buf),
@@ -78,7 +82,11 @@ impl Stream {
     }
 
     #[project]
-    pub(crate) fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+    pub(crate) fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
         #[project]
         match self.project() {
             Stream::Plain(stream) => stream.poll_write(cx, buf),

--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -3,8 +3,12 @@ use std::{
     io::{self, Cursor},
     pin::Pin,
     ptr,
+    sync::{
+        self,
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     task::{self, Poll},
-    sync::{self, Arc, atomic::{AtomicBool, Ordering}},
 };
 
 use chrono_tz::Tz;
@@ -16,8 +20,8 @@ use crate::{
     binary::Parser,
     errors::{DriverError, Error, Result},
     io::{read_to_end::read_to_end, Stream as InnerStream},
+    pool::{Inner, Pool},
     types::{Block, Cmd, Packet},
-    pool::{Pool, Inner},
 };
 use futures_core::Stream;
 use futures_util::StreamExt;

--- a/src/pool/futures/get_handle.rs
+++ b/src/pool/futures/get_handle.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, pin::Pin};
 
-use futures_core::{task::Context, Poll};
+use futures_core::task::{Context, Poll};
 
 use pin_project::pin_project;
 

--- a/src/retry_guard.rs
+++ b/src/retry_guard.rs
@@ -1,7 +1,7 @@
 use std::{mem, time::Duration};
 
 #[cfg(feature = "tokio_io")]
-use tokio::timer::Interval;
+use tokio::time::interval;
 
 use log::warn;
 
@@ -47,8 +47,8 @@ pub(crate) async fn retry_guard(
 
                 #[cfg(not(feature = "async_std"))]
                 {
-                    let mut interval = Interval::new_interval(duration);
-                    interval.next().await;
+                    let mut interval = interval(duration);
+                    interval.tick().await;
                 }
             }
         }

--- a/src/types/block/builder.rs
+++ b/src/types/block/builder.rs
@@ -3,12 +3,13 @@ use std::{borrow::Cow, marker};
 use chrono_tz::Tz;
 
 use crate::{
-    Block,
     errors::{Error, FromSqlError, Result},
     types::{
-        block::ColumnIdx, ColumnType,
-        column::{ArcColumnWrapper, ColumnData, Either}, Column, Value,
+        block::ColumnIdx,
+        column::{ArcColumnWrapper, ColumnData, Either},
+        Column, ColumnType, Value,
     },
+    Block,
 };
 
 pub trait RowBuilder {
@@ -131,7 +132,7 @@ mod test {
 
     use crate::{
         row,
-        types::{Decimal, SqlType, Simple},
+        types::{Decimal, Simple, SqlType},
     };
 
     use super::*;

--- a/src/types/block/mod.rs
+++ b/src/types/block/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     errors::{Error, FromSqlError, Result},
     types::{
         column::{self, ArcColumnWrapper, Column, ColumnFrom},
-        FromSql, SqlType, ColumnType, Simple, Complex
+        ColumnType, Complex, FromSql, Simple, SqlType,
     },
 };
 

--- a/src/types/block/row.rs
+++ b/src/types/block/row.rs
@@ -2,7 +2,7 @@ use std::{marker, sync::Arc};
 
 use crate::{
     errors::Result,
-    types::{Block, block::ColumnIdx, ColumnType, Column, FromSql, SqlType},
+    types::{block::ColumnIdx, Block, Column, ColumnType, FromSql, SqlType},
 };
 
 /// A row from Clickhouse

--- a/src/types/column/array.rs
+++ b/src/types/column/array.rs
@@ -116,7 +116,7 @@ mod test {
     use std::io::Cursor;
 
     use super::*;
-    use crate::{Block, types::Simple};
+    use crate::{types::Simple, Block};
 
     #[test]
     fn test_write_and_read() {

--- a/src/types/column/decimal.rs
+++ b/src/types/column/decimal.rs
@@ -4,15 +4,14 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        ColumnType,
         column::{
-            BoxColumnWrapper, column_data::BoxColumnData, column_data::ColumnData,
-            ColumnFrom, ColumnWrapper, Either, list::List, nullable::NullableColumnData,
+            column_data::BoxColumnData, column_data::ColumnData, list::List,
+            nullable::NullableColumnData, BoxColumnWrapper, ColumnFrom, ColumnWrapper, Either,
             VectorColumnData,
         },
-        Column,
         decimal::{Decimal, NoBits},
-        from_sql::FromSql, SqlType, Value, ValueRef,
+        from_sql::FromSql,
+        Column, ColumnType, SqlType, Value, ValueRef,
     },
 };
 

--- a/src/types/column/fixed_string.rs
+++ b/src/types/column/fixed_string.rs
@@ -4,8 +4,8 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        column::column_data::BoxColumnData, from_sql::*, Column, SqlType, Value,
-        ValueRef, ColumnType
+        column::column_data::BoxColumnData, from_sql::*, Column, ColumnType, SqlType, Value,
+        ValueRef,
     },
 };
 

--- a/src/types/column/iter.rs
+++ b/src/types/column/iter.rs
@@ -1,16 +1,13 @@
 #![allow(clippy::cast_ptr_alignment)]
 
-use std::{
-    iter::FusedIterator,
-    marker, mem, ptr, slice,
-};
+use std::{iter::FusedIterator, marker, mem, ptr, slice};
 
 use chrono::{prelude::*, Date};
 use chrono_tz::Tz;
 
 use crate::{
     errors::{Error, FromSqlError, Result},
-    types::{column::StringPool, decimal::NoBits, Column, Decimal, SqlType, Simple},
+    types::{column::StringPool, decimal::NoBits, Column, Decimal, Simple, SqlType},
 };
 
 macro_rules! simple_num_iterable {

--- a/src/types/column/mod.rs
+++ b/src/types/column/mod.rs
@@ -6,21 +6,21 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::{Error, FromSqlError, Result},
     types::{
+        column::iter::SimpleIterable,
         column::{
             column_data::ArcColumnData,
             decimal::{DecimalAdapter, NullableDecimalAdapter},
             fixed_string::{FixedStringAdapter, NullableFixedStringAdapter},
             string::StringAdapter,
         },
-        column::iter::SimpleIterable,
         decimal::NoBits,
         SqlType, Value, ValueRef,
     },
 };
 
+use self::chunk::ChunkColumnData;
 pub(crate) use self::{column_data::ColumnData, string_pool::StringPool};
 pub use self::{concat::ConcatColumnData, numeric::VectorColumnData};
-use self::chunk::ChunkColumnData;
 
 mod array;
 mod chunk;
@@ -141,7 +141,7 @@ impl Column<Simple> {
     /// # use std::env;
     /// # use clickhouse_rs::{errors::Error, Pool, errors::Result};
     /// # use futures_util::stream::StreamExt;
-    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
     /// # let ret: Result<()> = rt.block_on(async {
     /// #     let database_url = "tcp://localhost:9000";
     /// #     let pool = Pool::new(database_url);

--- a/src/types/column/string.rs
+++ b/src/types/column/string.rs
@@ -4,12 +4,11 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        ColumnType,
         column::{
-            array::ArrayColumnData, BoxColumnWrapper, ColumnWrapper, Either,
-            list::List, nullable::NullableColumnData, StringPool,
+            array::ArrayColumnData, list::List, nullable::NullableColumnData, BoxColumnWrapper,
+            ColumnWrapper, Either, StringPool,
         },
-        Column, FromSql, SqlType, Value, ValueRef,
+        Column, ColumnType, FromSql, SqlType, Value, ValueRef,
     },
 };
 

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -115,13 +115,13 @@ impl PartialEq for Decimal {
                 let delta = other.scale() - self.scale();
                 let underlying = self.underlying * FACTORS10[delta];
                 other.underlying == underlying
-            },
+            }
             Ordering::Equal => self.underlying == other.underlying,
             Ordering::Greater => {
                 let delta = self.scale() - other.scale();
                 let underlying = other.underlying * FACTORS10[delta];
                 self.underlying == underlying
-            },
+            }
         }
     }
 }
@@ -190,7 +190,7 @@ impl Decimal {
     /// ```rust
     /// # use std::env;
     /// # use clickhouse_rs::{Pool, types::Decimal, errors::Result};
-    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
     /// # let ret: Result<()> = rt.block_on(async {
     /// #     let database_url = env::var("DATABASE_URL")
     /// #         .unwrap_or("tcp://localhost:9000?compression=lz4".into());

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,7 +9,7 @@ use crate::errors::ServerError;
 
 pub use self::{
     block::{Block, RCons, RNil, Row, RowBuilder, Rows},
-    column::{Column, ColumnType, Simple, Complex},
+    column::{Column, ColumnType, Complex, Simple},
     decimal::Decimal,
     from_sql::FromSql,
     options::Options,

--- a/src/types/query_result/mod.rs
+++ b/src/types/query_result/mod.rs
@@ -11,8 +11,8 @@ use log::info;
 use crate::{
     errors::Result,
     types::{
-        block::BlockRef, query_result::stream_blocks::BlockStream, Block, Cmd, Query, Row,
-        Rows, Complex, Simple
+        block::BlockRef, query_result::stream_blocks::BlockStream, Block, Cmd, Complex, Query, Row,
+        Rows, Simple,
     },
     ClientHandle,
 };
@@ -49,7 +49,7 @@ impl<'a> QueryResult<'a> {
     /// # use clickhouse_rs::{Pool, errors::Result};
     /// # use futures_util::{future, TryStreamExt};
     /// #
-    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
     /// # let ret: Result<()> = rt.block_on(async {
     /// #
     /// #     let database_url = env::var("DATABASE_URL")
@@ -79,11 +79,7 @@ impl<'a> QueryResult<'a> {
 
                 let context = c.context.clone();
 
-                let inner = c
-                    .inner
-                    .take()
-                    .unwrap()
-                    .call(Cmd::SendQuery(query, context));
+                let inner = c.inner.take().unwrap().call(Cmd::SendQuery(query, context));
 
                 BlockStream::<'a>::new(c, inner)
             })

--- a/tests/clickhouse.rs
+++ b/tests/clickhouse.rs
@@ -1,8 +1,19 @@
-use std::{env, f64::EPSILON, fmt, sync::{Arc, atomic::{Ordering, AtomicUsize}}};
+use std::{
+    env,
+    f64::EPSILON,
+    fmt,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use chrono::prelude::*;
 use chrono_tz::Tz;
-use futures_util::{future, stream::StreamExt, try_stream::TryStreamExt};
+use futures_util::{
+    future,
+    stream::{StreamExt, TryStreamExt},
+};
 
 use clickhouse_rs::{
     errors::Error,
@@ -194,7 +205,7 @@ async fn test_select() -> Result<(), Error> {
     assert_eq!(3, r.get::<u64, _>(0, 0)?);
 
     let r = c
-        .query("SELECT COUNT(*) FROM clickhouse_test_select WHERE datetime = '2014-07-08 14:00:00'")
+        .query("SELECT COUNT(*) FROM clickhouse_test_select WHERE datetime = toDateTime('2014-07-08 14:00:00', 'UTC')")
         .fetch_all()
         .await?;
     assert_eq!(2, r.get::<u64, _>(0, 0)?);
@@ -844,7 +855,7 @@ fn test_reconnect() {
     for _ in 0..2 {
         let pool = pool.clone();
         let counter = counter.clone();
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
         let ret: Result<(), Error> = rt.block_on(async move {
             let mut client = pool.get_handle().await?;
 


### PR DESCRIPTION
This pull request is mostly about upgrading `tokio` and `futures-*` crates to the latest stablized version. Some `rustfmt` is applied as well.