### PR TITLE
Update async-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = ["io-util", "time", "net", "sync", "rt-threaded"]
 optional = true
 
 [dependencies.async-std]
-version = "0.99.11"
+version = "1.4"
 optional = true
 
 [dependencies.clickhouse-rs-cityhash-sys]


### PR DESCRIPTION
Just quickly updating async-std. 

I noticed that async-std had previously been updated to 1.2 before, but it was somehow reverted again to some alpha version. I think this might have been by accident?

Ran `cargo test --no-default-features --features async_std` locally, looked like everything was working fine!
