### PR TITLE
Do not silently drop connection construction task if the queue is full

### DIFF
--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -183,10 +183,8 @@ impl Pool {
                 let new_conn_created = || {
                     let conn_count = self.inner.conn_count();
 
-                    if conn_count < self.max {
-                        if let Ok(_) = self.inner.new.push(self.new_connection()) {
-                            return true
-                        }
+                    if conn_count < self.max && self.inner.new.push(self.new_connection()).is_ok() {
+                        return true;
                     }
                     self.inner.tasks.push(task::current());
                     false


### PR DESCRIPTION
This PR attempts to fix a potential problematic usage of `ArrayQueue`, where connection construction task could be silently dropped without saving the task waker.