### PR TITLE
more readable error for set_nodelay and set_keepalive

### DIFF
--- a/src/io/stream.rs
+++ b/src/io/stream.rs
@@ -35,7 +35,7 @@ impl Stream {
             Self::Plain(ref mut stream) => stream.set_nodelay(nodelay),
             #[cfg(feature = "tls")]
             Self::Secure(ref mut stream) => stream.get_mut().get_mut().set_nodelay(nodelay),
-        }
+        }.map_err(|err| io::Error::new(err.kind(), format!("set_nodelay error: {}", err)))
     }
 
     pub(crate) fn set_keepalive(&mut self, keepalive: Option<Duration>) -> io::Result<()> {
@@ -43,7 +43,7 @@ impl Stream {
             Self::Plain(ref mut stream) => stream.set_keepalive(keepalive),
             #[cfg(feature = "tls")]
             Self::Secure(ref mut stream) => stream.get_mut().get_mut().set_keepalive(keepalive),
-        }
+        }.map_err(|err| io::Error::new(err.kind(), format!("set_keepalive error: {}", err)))
     }
 }
 


### PR DESCRIPTION
Hello.

I debugged the code on my macbook and everything worked, but when I started on the server, I got an error:

Input/output error: `Invalid argument (os error 22)`

The mistake is incomprehensible and I spent a lot of time, it turned out that keepalive does not work on centos. I think that with this code the error can be found faster.