### PR TITLE
add eof in query exception

### DIFF
--- a/src/types/query_result/stream_blocks.rs
+++ b/src/types/query_result/stream_blocks.rs
@@ -77,6 +77,7 @@ impl<'a> Stream for BlockStream<'a> {
                 }
                 Packet::ProfileInfo(_) | Packet::Progress(_) => {}
                 Packet::Exception(exception) => {
+                    self.eof = true;
                     return Poll::Ready(Some(Err(Error::Server(exception))))
                 }
                 Packet::Block(block) => {


### PR DESCRIPTION
In my case when query result return exception, after many errors will hang all requests

and now pool info is:

```
Pool { min: 10, max: 20, new connections count: 0, idle connections count: 0, \
  tasks count: 3711, ongoing connections count: 20 }
```

add `eof=true` in Packet::Exception can fix it