### PR TITLE
backport the client timeout to async-await branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ parameters:
     * `2` - Read data and change settings queries are allowed.
 
 - `connection_timeout` - Timeout for connection (defaults to `500 ms`)
+- `query_timeout` - Timeout for queries (defaults to `180 sec`).
+- `insert_timeout` - Timeout for inserts (defaults to `180 sec`).
+- `execute_timeout` - Timeout for execute (defaults to `180 sec`).
 - `keepalive` - TCP keep alive timeout in milliseconds.
 - `nodelay` - Whether to enable `TCP_NODELAY` (defaults to `true`).
  
@@ -56,6 +59,7 @@ parameters:
 - `send_retries` - Count of retry to send request to server. (defaults to `3`).
 - `retry_timeout` - Amount of time to wait before next retry. (defaults to `5 sec`).
 - `ping_timeout` - Timeout for ping (defaults to `500 ms`).
+
 
 - `alt_hosts` - Comma separated list of single address host for load-balancing.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ impl ClientHandle {
     where
         Query: From<Q>,
     {
-        let timeout = try_opt!(self.context.options.get()).execute_timeout.unwrap_or(Duration::from_secs(0));
+        let timeout = try_opt!(self.context.options.get()).execute_timeout.unwrap_or_else(||Duration::from_secs(0));
         let context = self.context.clone();
         let query = Query::from(sql);
         with_timeout(
@@ -416,7 +416,7 @@ impl ClientHandle {
     where
         Query: From<Q>,
     {
-        let timeout = try_opt!(self.context.options.get()).insert_timeout.unwrap_or(Duration::from_secs(0));
+        let timeout = try_opt!(self.context.options.get()).insert_timeout.unwrap_or_else(||Duration::from_secs(0));
         let mut names: Vec<_> = Vec::with_capacity(block.column_count());
         for column in block.columns() {
             names.push(try_opt!(column_name_to_string(column.name())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ macro_rules! row {
     };
 }
 
+#[macro_export]
 macro_rules! try_opt {
     ($expr:expr) => {
         match $expr {
@@ -363,35 +364,41 @@ impl ClientHandle {
     where
         Query: From<Q>,
     {
+        let timeout = try_opt!(self.context.options.get()).execute_timeout.unwrap_or(Duration::from_secs(0));
         let context = self.context.clone();
         let query = Query::from(sql);
+        with_timeout(
+            async {
+                self.wrap_future(move |c| {
+                    info!("[execute query] {}", query.get_sql());
 
-        self.wrap_future(move |c| {
-            info!("[execute query] {}", query.get_sql());
+                    let transport = c.inner.take().unwrap();
 
-            let transport = c.inner.take().unwrap();
+                    async move {
+                        let mut h = None;
 
-            async move {
-                let mut h = None;
+                        let transport = transport.clear().await?;
+                        let mut stream = transport.call(Cmd::SendQuery(query, context.clone()));
 
-                let transport = transport.clear().await?;
-                let mut stream = transport.call(Cmd::SendQuery(query, context.clone()));
+                        while let Some(packet) = stream.next().await {
+                            match packet {
+                                Ok(Packet::Eof(inner)) => h = Some(inner),
+                                Ok(Packet::Block(_))
+                                | Ok(Packet::ProfileInfo(_))
+                                | Ok(Packet::Progress(_)) => (),
+                                Ok(Packet::Exception(e)) => return Err(Error::Server(e)),
+                                Err(e) => return Err(Error::Io(e)),
+                                _ => return Err(Error::Driver(DriverError::UnexpectedPacket)),
+                            }
+                        }
 
-                while let Some(packet) = stream.next().await {
-                    match packet {
-                        Ok(Packet::Eof(inner)) => h = Some(inner),
-                        Ok(Packet::Block(_))
-                        | Ok(Packet::ProfileInfo(_))
-                        | Ok(Packet::Progress(_)) => (),
-                        Ok(Packet::Exception(e)) => return Err(Error::Server(e)),
-                        Err(e) => return Err(Error::Io(e)),
-                        _ => return Err(Error::Driver(DriverError::UnexpectedPacket)),
+                        Ok(h.unwrap())
                     }
-                }
-
-                Ok(h.unwrap())
-            }
-        })
+                })
+                .await
+            },
+            timeout,
+        )
         .await
     }
 
@@ -409,6 +416,7 @@ impl ClientHandle {
     where
         Query: From<Q>,
     {
+        let timeout = try_opt!(self.context.options.get()).insert_timeout.unwrap_or(Duration::from_secs(0));
         let mut names: Vec<_> = Vec::with_capacity(block.column_count());
         for column in block.columns() {
             names.push(try_opt!(column_name_to_string(column.name())));
@@ -420,31 +428,37 @@ impl ClientHandle {
 
         let context = self.context.clone();
 
-        self.wrap_future(move |c| {
-            info!("[insert]     {}", query.get_sql());
-            let transport = c.inner.take().unwrap();
+        with_timeout(
+            async {
+                self.wrap_future(move |c| {
+                    info!("[insert]     {}", query.get_sql());
+                    let transport = c.inner.take().unwrap();
 
-            async move {
-                let transport = transport.clear().await?;
-                let stream = transport.call(Cmd::SendQuery(query, context.clone()));
+                    async move {
+                        let transport = transport.clear().await?;
+                        let stream = transport.call(Cmd::SendQuery(query, context.clone()));
 
-                let (transport, b) = stream.read_block().await?;
-                let dst_block = b.unwrap();
+                        let (transport, b) = stream.read_block().await?;
+                        let dst_block = b.unwrap();
 
-                let casted_block = match block.cast_to(&dst_block) {
-                    Ok(value) => value,
-                    Err(err) => return Err(err),
-                };
+                        let casted_block = match block.cast_to(&dst_block) {
+                            Ok(value) => value,
+                            Err(err) => return Err(err),
+                        };
 
-                let send_cmd = Cmd::Union(
-                    Box::new(Cmd::SendData(casted_block, context.clone())),
-                    Box::new(Cmd::SendData(Block::default(), context.clone())),
-                );
+                        let send_cmd = Cmd::Union(
+                            Box::new(Cmd::SendData(casted_block, context.clone())),
+                            Box::new(Cmd::SendData(Block::default(), context.clone())),
+                        );
 
-                let (transport, _) = transport.call(send_cmd).read_block().await?;
-                Ok(transport)
-            }
-        })
+                        let (transport, _) = transport.call(send_cmd).read_block().await?;
+                        Ok(transport)
+                    }
+                })
+                .await
+            },
+            timeout,
+        )
         .await
     }
 

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -183,6 +183,15 @@ pub struct Options {
     /// Timeout for connection (defaults to `500 ms`)
     pub(crate) connection_timeout: Duration,
 
+    /// Timeout for queries (defaults to `180 sec`)
+    pub(crate) query_timeout: Duration,
+
+    /// Timeout for inserts (defaults to `180 sec`)
+    pub(crate) insert_timeout: Option<Duration>,
+
+    /// Timeout for execute (defaults to `180 sec`)
+    pub(crate) execute_timeout: Option<Duration>,
+
     /// Enable TLS encryption (defaults to `false`)
     #[cfg(feature = "tls")]
     pub(crate) secure: bool,
@@ -240,6 +249,9 @@ impl Default for Options {
             retry_timeout: Duration::from_secs(5),
             ping_timeout: Duration::from_millis(500),
             connection_timeout: Duration::from_millis(500),
+            query_timeout: Duration::from_secs(180),
+            insert_timeout: Some(Duration::from_secs(180)),
+            execute_timeout: Some(Duration::from_secs(180)),
             #[cfg(feature = "tls")]
             secure: false,
             #[cfg(feature = "tls")]
@@ -352,6 +364,21 @@ impl Options {
         => connection_timeout: Duration
     }
 
+    property! {
+        /// Timeout for query (defaults to `180,000 ms`).
+        => query_timeout: Duration
+    }
+
+    property! {
+        /// Timeout for insert (defaults to `180,000 ms`).
+        => insert_timeout: Option<Duration>
+    }
+
+    property! {
+        /// Timeout for execute (defaults to `180 sec`).
+        => execute_timeout: Option<Duration>
+    }
+
     #[cfg(feature = "tls")]
     property! {
         /// Establish secure connection (default is `false`).
@@ -449,6 +476,15 @@ where
             "connection_timeout" => {
                 options.connection_timeout = parse_param(key, value, parse_duration)?
             }
+            "query_timeout" => {
+                options.query_timeout = parse_param(key, value, parse_duration)?
+            },
+            "insert_timeout" => {
+                options.insert_timeout = parse_param(key, value, parse_opt_duration)?
+            }
+            "execute_timeout" => {
+                options.execute_timeout = parse_param(key, value, parse_opt_duration)?
+            },
             "compression" => options.compression = parse_param(key, value, parse_compression)?,
             #[cfg(feature = "tls")]
             "secure" => options.secure = parse_param(key, value, bool::from_str)?,


### PR DESCRIPTION
Hello.

The async-await branch is missing the query_timeout/insert_timeout/execute_timeout which is important in our scene.

BTW: the codebase is not formatted by `cargo fmt`:)

> sorry, no time to write tests now 