### PR TITLE
export FromSqlResult type

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -13,7 +13,8 @@ pub use self::{
     column::{Column, ColumnType, Simple, Complex},
     decimal::Decimal,
     enums::{Enum16, Enum8},
-    from_sql::FromSql,
+    from_sql::{FromSql, FromSqlResult},
+    value_ref::ValueRef,
     options::Options,
     query::Query,
     query_result::QueryResult,
@@ -27,7 +28,6 @@ pub(crate) use self::{
     options::{IntoOptions, OptionsSource},
     stat_buffer::StatBuffer,
     unmarshal::Unmarshal,
-    value_ref::ValueRef,
 };
 
 pub(crate) mod column;


### PR DESCRIPTION
Tiny fix :)

Hello. We needs export the FromSqlResult Type because of the `from_sql::FromSql` which has exported

Signed-off-by: detailyang <detailyang@gmail.com>