### PR TITLE
Update tokio to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["tests/*", "examples/*"]
 
 [features]
 default = ["tokio_io"]
-tls = ["tokio-tls", "native-tls"]
+tls = ["tokio-native-tls", "native-tls"]
 async_std = ["async-std"]
 tokio_io = ["tokio"]
 
@@ -40,9 +40,9 @@ version = "0.3.5"
 features = ["sink"]
 
 [dependencies.tokio]
-version = "0.2.22"
+version = "0.3"
 default-features = false
-features = ["io-util", "time", "net", "sync", "rt-threaded"]
+features = ["io-util", "time", "net", "sync", "rt-multi-thread"]
 optional = true
 
 [dependencies.async-std]
@@ -61,8 +61,8 @@ features = ["std", "serde"]
 version = "0.2"
 optional = true
 
-[dependencies.tokio-tls]
-version = "0.3.1"
+[dependencies.tokio-native-tls]
+version = "0.2"
 optional = true
 
 [dev-dependencies]
@@ -70,6 +70,6 @@ env_logger = "^0.7"
 rand = "^0.7"
 
 [dev-dependencies.tokio]
-version = "0.2.0"
+version = "0.3"
 default-features = false
 features = ["macros"]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, io, result, str::Utf8Error, string::FromUtf8Error};
 
 use thiserror::Error;
 #[cfg(feature = "tokio_io")]
-use tokio::time::Elapsed;
+use tokio::time::error::Elapsed;
 use url::ParseError;
 
 /// Clickhouse error codes

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -388,11 +388,11 @@ mod test {
         let barrier = Arc::new(AtomicBool::new(true));
         let pool = Pool::new(options);
 
-        let mut runtime = Builder::new()
-            .threaded_scheduler()
+        let runtime = Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
+
         let tasks: Vec<_> = (0..100)
             .map(|_| {
                 let local_pool = pool.clone();

--- a/src/retry_guard.rs
+++ b/src/retry_guard.rs
@@ -44,7 +44,7 @@ pub(crate) async fn retry_guard(
 
                 #[cfg(not(feature = "async_std"))]
                 {
-                    tokio::time::delay_for(duration).await;
+                    tokio::time::sleep(duration).await;
                 }
             }
         }


### PR DESCRIPTION
This PR upgrades Tokio to v0.3.

Unfortunately, Tokio (temporarily) dropped support for `set_keepalive`, so I had to comment this out for now. See these issues for details:

https://github.com/tokio-rs/tokio/issues/3082
https://github.com/tokio-rs/tokio/issues/3109

I'm not sure how important this `set_keepalive` is to you. Depending on that, we might have to wait until Tokio adds it back, or we could just throw it out entirely (since no backend supports it now).