### PR TITLE
IPv6 addresses are stored in clickhouse in the wrong byte order

### DIFF
--- a/src/types/column/ip.rs
+++ b/src/types/column/ip.rs
@@ -135,9 +135,7 @@ impl ColumnFrom for Vec<Ipv6Addr> {
     fn column_from<W: ColumnWrapper>(data: Self) -> W::Wrapper {
         let mut inner = Vec::with_capacity(data.len());
         for ip in data {
-            let mut buffer = ip.octets();
-            buffer.reverse();
-            inner.extend(&buffer);
+            inner.extend(&ip.octets());
         }
 
         W::wrap(IpColumnData::<Ipv6> {
@@ -209,9 +207,7 @@ impl ColumnFrom for Vec<Option<Ipv6Addr>> {
                     nulls.push(1);
                 }
                 Some(ip) => {
-                    let mut buffer = ip.octets();
-                    buffer.reverse();
-                    inner.extend(&buffer);
+                    inner.extend(&ip.octets());
                     nulls.push(0);
                 }
             }

--- a/src/types/column/iter/mod.rs
+++ b/src/types/column/iter/mod.rs
@@ -343,7 +343,6 @@ impl<'a> Ipv6Iterator<'a> {
         let v = slice::from_raw_parts(self.ptr, 16);
         let mut m = [0_u8; 16];
         m.copy_from_slice(v);
-        m.reverse();
         self.ptr = self.ptr.offset(16) as *const u8;
 
         Ipv6Addr::from(m)

--- a/src/types/column/mod.rs
+++ b/src/types/column/mod.rs
@@ -407,10 +407,7 @@ impl<K: ColumnType> Column<K> {
                 for i in 0..n {
                     let source = self.at(i).as_str().unwrap();
                     let ip: Ipv6Addr = source.parse().unwrap();
-                    let mut buffer = [0_u8; 16];
-                    buffer.copy_from_slice(&ip.octets());
-                    buffer.reverse();
-                    inner.extend(&buffer);
+                    inner.extend(&ip.octets());
                 }
 
                 let data = Arc::new(IpColumnData::<Ipv6> {

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -409,9 +409,7 @@ pub(crate) fn decode_ipv4(octets: &[u8; 4]) -> Ipv4Addr {
 }
 
 pub(crate) fn decode_ipv6(octets: &[u8; 16]) -> Ipv6Addr {
-    let mut buffer = *octets;
-    buffer.reverse();
-    Ipv6Addr::from(buffer)
+    Ipv6Addr::from(*octets)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The fix for issue #113 reversed the byte order for ipv6 addresses as well leading to incorrectly stored IPv6 addresses.

This change fixes that and adds two testcases verifying the fix.