### PR TITLE
Don't use default features for chrono since that pulls in an old version of the time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ tokio_io = ["tokio"]
 
 [dependencies]
 byteorder = "^1.3"
-chrono = "0.4"
 chrono-tz = "0.5"
 crossbeam = "0.8.0"
 thiserror = "1.0.20"
@@ -64,6 +63,11 @@ optional = true
 [dependencies.tokio-native-tls]
 version = "^0.3"
 optional = true
+
+[dependencies.chrono]
+version = "0.4"
+default-features = false
+features = [ "std" ]
 
 [dev-dependencies]
 env_logger = "^0.8"


### PR DESCRIPTION
The oldtime feature causes chrono to depend on an old version of the time crate. It is enabled by default for backward compatibility, but that is not needed by clickhouse-rs so it can be removed to reduce size and warnings caused by duplicate dependencies.