### PR TITLE
bump up tokio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.3.12"
 features = ["sink"]
 
 [dependencies.tokio]
-version = "1.0"
+version = "1.5"
 default-features = false
 features = ["io-util", "time", "net", "sync", "rt-multi-thread"]
 optional = true
@@ -74,6 +74,6 @@ env_logger = "^0.8"
 rand = "^0.8"
 
 [dev-dependencies.tokio]
-version = "1.0"
+version = "1.5"
 default-features = false
 features = ["macros"]


### PR DESCRIPTION
In the latest stable rust toolchain, the same error from #118 is shown. Bumping the version of `tokio` to 1.5 solves the issue
```
error[E0277]: `GetHandle` is not a future
  --> src/main.rs:72:22
   |
72 |     let mut client = pool.get_handle().await?;
   |                      ^^^^^^^^^^^^^^^^^^^^^^^ `GetHandle` is not a future
   |
   = help: the trait `Future` is not implemented for `GetHandle`
   = note: required by `poll`
```
