### PR TITLE
Adds missing methods for IP address types

### DIFF
--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -79,7 +79,9 @@ impl<'a> PartialEq for ValueRef<'a> {
                 let that_time = to_datetime(*that, that_precision2, that_tz);
 
                 this_time == that_time
-            }
+            },
+            (ValueRef::Ipv4(a), ValueRef::Ipv4(b)) => a == b,
+            (ValueRef::Ipv6(a), ValueRef::Ipv6(b)) => a == b,
             _ => false,
         }
     }


### PR DESCRIPTION
- Adds match arms to compare Value::Ipv4/6
- Adds impls for converting from Rust's native IP address types to Value
  variants.
- Adds tests for these.