### PR TITLE
Add push_value method to Block

### DIFF
--- a/src/types/block/builder.rs
+++ b/src/types/block/builder.rs
@@ -68,6 +68,15 @@ where
     }
 }
 
+impl RowBuilder for Vec<(&'static str, Value)> {
+    fn apply<K: ColumnType>(self, block: &mut Block<K>) -> Result<()> {
+        for (k, v) in self {
+            block.push_value(k, v)?;
+        }
+        Ok(())
+    }
+}
+
 impl RowBuilder for Vec<(String, Value)> {
     fn apply<K: ColumnType>(self, block: &mut Block<K>) -> Result<()> {
         for (k, v) in self {

--- a/src/types/block/mod.rs
+++ b/src/types/block/mod.rs
@@ -353,7 +353,7 @@ impl<K: ColumnType> Block<K> {
 }
 
 impl Block<Simple> {
-    pub(crate) fn concat(blocks: &[Self]) -> Block<Complex> {
+    pub fn concat(blocks: &[Self]) -> Block<Complex> {
         let first = blocks.first().expect("blocks should not be empty.");
 
         for block in blocks {

--- a/src/types/block/mod.rs
+++ b/src/types/block/mod.rs
@@ -1,10 +1,11 @@
 use std::{
+    borrow::Cow,
     cmp,
     default::Default,
     fmt,
     io::{Cursor, Read},
-    os::raw::c_char,
     marker::PhantomData,
+    os::raw::c_char,
 };
 
 use byteorder::{LittleEndian, WriteBytesExt};
@@ -16,8 +17,8 @@ use crate::{
     binary::{protocol, Encoder, ReadEx},
     errors::{Error, FromSqlError, Result},
     types::{
-        column::{self, ArcColumnWrapper, Column, ColumnFrom},
-        FromSql, SqlType, ColumnType, Simple, Complex
+        column::{self, ArcColumnWrapper, Column, ColumnData, ColumnFrom},
+        ColumnType, Complex, FromSql, Simple, SqlType, Value,
     },
 };
 
@@ -25,7 +26,7 @@ use self::chunk_iterator::ChunkIterator;
 pub(crate) use self::row::BlockRef;
 pub use self::{
     block_info::BlockInfo,
-    builder::{RCons, RNil, RowBuilder},
+    builder::{extract_timezone, RCons, RNil, RowBuilder},
     row::{Row, Rows},
 };
 
@@ -77,6 +78,86 @@ pub struct Block<K: ColumnType = Simple> {
     info: BlockInfo,
     columns: Vec<Column<K>>,
     capacity: usize,
+}
+
+impl<K: ColumnType> Block<K> {
+    /// Adds a value to a block column
+    ///
+    /// # Arguments
+    /// * `key` - A string representing the column name
+    /// * `value` - The value to add to the end of the column
+    ///
+    /// This method should be cautiously used outside of RowBuilder implementations.
+    /// Clickhouse requires that every column has the same number of items
+    ///
+    ///
+    /// This can be used to add the RowBuilder trait to custom-defined structs
+    /// ```
+    /// use clickhouse_rs::errors;
+    /// use clickhouse_rs::types;
+    ///
+    /// struct Person {
+    ///  name: String,
+    ///  age: i32
+    /// }
+    ///
+    /// impl types::RowBuilder for Person {
+    ///     fn apply<K>(
+    ///        self,
+    ///        block: &mut types::Block<K>,
+    ///     ) -> Result<(), errors::Error>
+    ///     where
+    ///         K: types::ColumnType,
+    ///     {
+    ///          block.push_value("name", self.name.into())?;
+    ///          block.push_value("age", self.age.into())?;
+    ///          Ok(())
+    ///     }
+    ///}
+    ///
+    /// # fn main(){
+    /// let mut block = types::Block::new();
+    /// let person = Person {
+    ///   name: "Bob".to_string(),
+    ///   age: 42,
+    /// };
+    ///
+    /// block.push(person).unwrap();
+    /// assert_eq!(block.row_count(), 1);
+    /// # }
+    /// ```
+    /// Note this requires the types to have either Into or From for Value implemented
+    pub fn push_value(&mut self, key: &str, value: Value) -> Result<()> {
+        let col_index = match key.get_index(&self.columns) {
+            Ok(col_index) => col_index,
+            Err(Error::FromSql(FromSqlError::OutOfRange)) => {
+                if self.row_count() <= 1 {
+                    let sql_type = From::from(value.clone());
+
+                    let timezone = extract_timezone(&value);
+
+                    let column = Column {
+                        name: key.clone().into(),
+                        data: <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+                            sql_type,
+                            timezone,
+                            self.capacity,
+                        )?,
+                        _marker: PhantomData,
+                    };
+
+                    self.columns.push(column);
+                    return self.push_value(key, value);
+                } else {
+                    return Err(Error::FromSql(FromSqlError::OutOfRange));
+                }
+            }
+            Err(err) => return Err(err),
+        };
+
+        self.columns[col_index].push(value);
+        Ok(())
+    }
 }
 
 impl<L: ColumnType, R: ColumnType> PartialEq<Block<R>> for Block<L> {
@@ -148,7 +229,7 @@ impl Block {
         Self {
             info: Default::default(),
             columns: vec![],
-            capacity
+            capacity,
         }
     }
 


### PR DESCRIPTION
Closes #153 

The old put_param method had a Cow passed into it, but was never written to. Therefore, I thought &str was easier for downstream uses

Includes doctest