### PR TITLE
Fix and test TLS build

### DIFF
--- a/src/connecting_stream.rs
+++ b/src/connecting_stream.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::{errors::ConnectionError, io::Stream as InnerStream, Options};
 #[cfg(feature = "tls")]
-use tokio_tls::TlsStream;
+use tokio_native_tls::TlsStream;
 
 type Result<T> = std::result::Result<T, ConnectionError>;
 
@@ -179,7 +179,7 @@ impl ConnectingStream {
                             let (s, _) = socket.await?;
 
                             let cx = builder.build()?;
-                            let cx = tokio_tls::TlsConnector::from(cx);
+                            let cx = tokio_native_tls::TlsConnector::from(cx);
 
                             Ok(cx.connect(&host, s).await?)
                         })

--- a/src/io/stream.rs
+++ b/src/io/stream.rs
@@ -8,7 +8,7 @@ use std::{
 #[cfg(feature = "tokio_io")]
 use tokio::{net::TcpStream, io::ReadBuf};
 #[cfg(feature = "tls")]
-use tokio_tls::TlsStream;
+use tokio_native_tls::TlsStream;
 
 #[cfg(feature = "tokio_io")]
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -69,7 +69,7 @@ impl Stream {
         match *self {
             Self::Plain(ref mut stream) => stream.set_nodelay(nodelay),
             #[cfg(feature = "tls")]
-            Self::Secure(ref mut stream) => stream.get_mut().set_nodelay(nodelay),
+            Self::Secure(ref mut stream) => stream.get_mut().get_mut().get_mut().set_nodelay(nodelay),
         }.map_err(|err| io::Error::new(err.kind(), format!("set_nodelay error: {}", err)))
     }
 

--- a/tests/clickhouse.rs
+++ b/tests/clickhouse.rs
@@ -30,9 +30,17 @@ use clickhouse_rs::{
 use uuid::Uuid;
 use Tz::UTC;
 
+#[cfg(not(feature = "tls"))]
 fn database_url() -> String {
     env::var("DATABASE_URL").unwrap_or_else(|_| {
         "tcp://localhost:9000?compression=lz4&ping_timeout=2s&retry_timeout=3s".into()
+    })
+}
+
+#[cfg(feature = "tls")]
+fn database_url() -> String {
+    env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "tcp://localhost:9440?compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&skip_verify=true".into()
     })
 }
 


### PR DESCRIPTION
It seems like some references to `tokio_tls` were overlooked when updating the `tokio-tls` dependency to `tokio-native-tls`.

The yandex ClickHouse image used for Travis CI doesn't expose TLS ports by default, so I didn't add anything to `.travis.yml`. But seeing as the TLS build literally had compile errors, perhaps adding `cargo build --features tls` would be worthwhile?