### PR TITLE
Detect TCP disconnects

### DIFF
--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -270,6 +270,10 @@ impl Stream for ClickhouseTransport {
             }
         }
 
+        if *this.done {
+            return Poll::Ready(None);
+        }
+
         // Try to parse the new data!
         let ret = this.try_parse_msg();
 


### PR DESCRIPTION
In case of a TCP disconnect (i.e., server-side graceful TCP shutdown), query result stream should return error instead of just hanging indefinitely.

Before this change, it would hang due to `ClickhouseTransport::poll_next` returning `Pending` upon reaching EOF on socket stream.

In order to properly handle TCP disconnect:

1) `ClickhouseTransport` should detect this condition and return `None` to signal that there are no more packets
2) `BlockStream` should handle end of packets:

   1) Return error from `Stream::next()`
   2) Prevent reuse of connection in pool