### PR TITLE
Make Value fully constructible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ hostname = "^0.3"
 lazy_static = "1.4.0"
 lz4 = "1.23.2"
 pin-project = "1.0.8"
-url="^2"
+url = "^2"
 uuid = "0.8.1"
 combine = "4.2.3"
 percent-encoding = "2.1.0"
+either = "1.6.1"
 
 [dependencies.futures-util]
 version = "0.3.16"
@@ -68,7 +69,7 @@ optional = true
 [dependencies.chrono]
 version = "0.4"
 default-features = false
-features = [ "std" ]
+features = ["std"]
 
 [dev-dependencies]
 env_logger = "^0.9"

--- a/src/types/block/builder.rs
+++ b/src/types/block/builder.rs
@@ -1,14 +1,16 @@
 use std::{borrow::Cow, marker};
 
 use chrono_tz::Tz;
+use either::Either;
 
 use crate::{
-        Block,
     errors::{Error, FromSqlError, Result},
     types::{
-        block::ColumnIdx, ColumnType,
-        column::{ArcColumnWrapper, ColumnData, Either}, Column, Value,
+        block::ColumnIdx,
+        column::{ArcColumnWrapper, ColumnData},
+        Column, ColumnType, Value,
     },
+    Block,
 };
 
 pub trait RowBuilder {
@@ -91,7 +93,11 @@ fn put_param<K: ColumnType>(
 
                 let column = Column {
                     name: key.clone().into(),
-                    data: <dyn ColumnData>::from_type::<ArcColumnWrapper>(sql_type, timezone, block.capacity)?,
+                    data: <dyn ColumnData>::from_type::<ArcColumnWrapper>(
+                        sql_type,
+                        timezone,
+                        block.capacity,
+                    )?,
                     _marker: marker::PhantomData,
                 };
 
@@ -131,7 +137,7 @@ mod test {
 
     use crate::{
         row,
-        types::{Decimal, SqlType, Simple, DateTimeType},
+        types::{DateTimeType, Decimal, Simple, SqlType},
     };
 
     use super::*;
@@ -196,7 +202,10 @@ mod test {
         );
 
         assert_eq!(block.columns[13].sql_type(), SqlType::Date);
-        assert_eq!(block.columns[14].sql_type(), SqlType::DateTime(DateTimeType::Chrono));
+        assert_eq!(
+            block.columns[14].sql_type(),
+            SqlType::DateTime(DateTimeType::Chrono)
+        );
         assert_eq!(block.columns[15].sql_type(), SqlType::Decimal(18, 4));
     }
 }

--- a/src/types/column/date.rs
+++ b/src/types/column/date.rs
@@ -2,6 +2,7 @@ use std::{convert, fmt, sync::Arc};
 
 use chrono::{prelude::*, Date};
 use chrono_tz::Tz;
+use either::Either;
 
 use crate::{
     binary::{Encoder, ReadEx},
@@ -12,7 +13,7 @@ use crate::{
         list::List,
         nullable::NullableColumnData,
         numeric::save_data,
-        ArcColumnWrapper, ColumnFrom, ColumnWrapper, Either,
+        ArcColumnWrapper, ColumnFrom, ColumnWrapper,
     },
     types::{DateConverter, Marshal, SqlType, StatBuffer, Unmarshal, Value, ValueRef},
 };

--- a/src/types/column/decimal.rs
+++ b/src/types/column/decimal.rs
@@ -1,19 +1,19 @@
-use std::sync::Arc;
 use chrono_tz::Tz;
+use either::Either;
+use std::sync::Arc;
 
 use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        ColumnType,
         column::{
-            BoxColumnWrapper, column_data::BoxColumnData, column_data::ColumnData,
-            ColumnFrom, ColumnWrapper, Either, list::List, nullable::NullableColumnData,
+            column_data::BoxColumnData, column_data::ColumnData, list::List,
+            nullable::NullableColumnData, BoxColumnWrapper, ColumnFrom, ColumnWrapper,
             VectorColumnData,
         },
-        Column,
         decimal::{Decimal, NoBits},
-        from_sql::FromSql, SqlType, Value, ValueRef,
+        from_sql::FromSql,
+        Column, ColumnType, SqlType, Value, ValueRef,
     },
 };
 
@@ -51,7 +51,8 @@ impl DecimalColumnData {
             NoBits::N32 => "Int32",
             NoBits::N64 => "Int64",
         };
-        let inner = <dyn ColumnData>::load_data::<BoxColumnWrapper, _>(reader, type_name, size, tz)?;
+        let inner =
+            <dyn ColumnData>::load_data::<BoxColumnWrapper, _>(reader, type_name, size, tz)?;
 
         Ok(DecimalColumnData {
             inner,

--- a/src/types/column/enums.rs
+++ b/src/types/column/enums.rs
@@ -1,16 +1,17 @@
-use std::sync::Arc;
 use chrono_tz::Tz;
+use either::Either;
+use std::sync::Arc;
 
 use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        enums::{Enum16, Enum8},
         column::{
             column_data::BoxColumnData, column_data::ColumnData, list::List,
             nullable::NullableColumnData, BoxColumnWrapper, ColumnFrom, ColumnWrapper,
-            VectorColumnData, Either,
+            VectorColumnData,
         },
+        enums::{Enum16, Enum8},
         from_sql::FromSql,
         Column, ColumnType, SqlType, Value, ValueRef,
     },
@@ -40,7 +41,8 @@ impl Enum16ColumnData {
     ) -> Result<Self> {
         let type_name = "Int16";
 
-        let inner = <dyn ColumnData>::load_data::<BoxColumnWrapper, _>(reader, type_name, size, tz)?;
+        let inner =
+            <dyn ColumnData>::load_data::<BoxColumnWrapper, _>(reader, type_name, size, tz)?;
 
         Ok(Enum16ColumnData { enum_values, inner })
     }
@@ -235,7 +237,8 @@ impl Enum8ColumnData {
     ) -> Result<Self> {
         let type_name = "Int8";
 
-        let inner = <dyn ColumnData>::load_data::<BoxColumnWrapper, _>(reader, type_name, size, tz)?;
+        let inner =
+            <dyn ColumnData>::load_data::<BoxColumnWrapper, _>(reader, type_name, size, tz)?;
 
         Ok(Enum8ColumnData { enum_values, inner })
     }

--- a/src/types/column/nullable.rs
+++ b/src/types/column/nullable.rs
@@ -4,12 +4,16 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        column::{column_data::{BoxColumnData, ArcColumnData}, Either, ArcColumnWrapper, ColumnData},
+        column::{
+            column_data::{ArcColumnData, BoxColumnData},
+            ArcColumnWrapper, ColumnData,
+        },
         SqlType, Value, ValueRef,
     },
 };
 
 use chrono_tz::Tz;
+use either::Either;
 
 pub(crate) struct NullableColumnData {
     pub(crate) inner: ArcColumnData,
@@ -25,7 +29,8 @@ impl NullableColumnData {
     ) -> Result<Self> {
         let mut nulls = vec![0; size];
         reader.read_bytes(nulls.as_mut())?;
-        let inner = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, size, tz)?;
+        let inner =
+            <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, size, tz)?;
         Ok(NullableColumnData { inner, nulls })
     }
 }
@@ -100,8 +105,8 @@ impl ColumnData for NullableColumnData {
             if let Some(inner) = self.inner.cast_to(&self.inner, inner_target) {
                 return Some(Arc::new(NullableColumnData {
                     inner,
-                    nulls: self.nulls.clone()
-                }))
+                    nulls: self.nulls.clone(),
+                }));
             }
         }
         None

--- a/src/types/column/string.rs
+++ b/src/types/column/string.rs
@@ -1,15 +1,16 @@
 use std::{io::Write, string::ToString, sync::Arc};
 
+use either::Either;
+
 use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        ColumnType,
         column::{
-            array::ArrayColumnData, ArcColumnWrapper, ColumnWrapper, Either,
-            list::List, nullable::NullableColumnData, StringPool,
+            array::ArrayColumnData, list::List, nullable::NullableColumnData, ArcColumnWrapper,
+            ColumnWrapper, StringPool,
         },
-        Column, FromSql, SqlType, Value, ValueRef,
+        Column, ColumnType, FromSql, SqlType, Value, ValueRef,
     },
 };
 

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -1,12 +1,13 @@
 use chrono::prelude::*;
 use chrono_tz::Tz;
+use either::Either;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::types::{Enum16, Enum8};
 use crate::{
     errors::{Error, FromSqlError, Result},
     types::{
-        column::{datetime64::to_datetime, Either},
+        column::datetime64::to_datetime,
         value::{decode_ipv4, decode_ipv6},
         Decimal, SqlType, ValueRef,
     },
@@ -324,9 +325,10 @@ from_sql_impl! {
 
 #[cfg(test)]
 mod test {
-    use crate::types::{column::Either, from_sql::FromSql, DateTimeType, SqlType, ValueRef};
+    use crate::types::{from_sql::FromSql, DateTimeType, SqlType, ValueRef};
     use chrono::prelude::*;
     use chrono_tz::Tz;
+    use either::Either;
 
     #[test]
     fn test_u8() {

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -7,11 +7,12 @@ use std::{
 
 use chrono::prelude::*;
 use chrono_tz::Tz;
+use either::Either;
 
 use crate::types::{
-    column::{datetime64::to_datetime, Either},
+    column::datetime64::to_datetime,
     decimal::{Decimal, NoBits},
-    DateConverter, Enum16, Enum8, SqlType, DateTimeType, HasSqlType
+    DateConverter, DateTimeType, Enum16, Enum8, HasSqlType, SqlType,
 };
 
 use uuid::Uuid;
@@ -102,9 +103,7 @@ impl Value {
             SqlType::DateTime(DateTimeType::DateTime64(_, _)) => {
                 Value::DateTime64(0, (1, Tz::Zulu))
             }
-            SqlType::SimpleAggregateFunction(_, nested) => {
-                Value::default(nested.clone())
-            }
+            SqlType::SimpleAggregateFunction(_, nested) => Value::default(nested.clone()),
             SqlType::DateTime(_) => 0_u32.to_date(Tz::Zulu).into(),
             SqlType::Nullable(inner) => Value::Nullable(Either::Left(inner)),
             SqlType::Array(inner) => Value::Array(inner, Arc::new(Vec::default())),
@@ -177,7 +176,7 @@ impl fmt::Display for Value {
             Value::Decimal(v) => fmt::Display::fmt(v, f),
             Value::Ipv4(v) => {
                 write!(f, "{}", decode_ipv4(v))
-            },
+            }
             Value::Ipv6(v) => {
                 write!(f, "{}", decode_ipv6(v))
             }
@@ -230,7 +229,7 @@ impl convert::From<Value> for SqlType {
             Value::DateTime64(_, params) => {
                 let (precision, tz) = params;
                 SqlType::DateTime(DateTimeType::DateTime64(precision, tz))
-            },
+            }
         }
     }
 }
@@ -322,7 +321,7 @@ impl convert::From<Uuid> for Value {
 
 impl convert::From<bool> for Value {
     fn from(v: bool) -> Value {
-        Value::UInt8(if v {1} else {0})
+        Value::UInt8(if v { 1 } else { 0 })
     }
 }
 
@@ -532,7 +531,10 @@ mod test {
     fn test_from_datetime_utc() {
         let date_time_value: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(14, 0, 0);
         let v = Value::from(date_time_value);
-        assert_eq!(v, Value::DateTime(date_time_value.timestamp() as u32, Tz::UTC));
+        assert_eq!(
+            v,
+            Value::DateTime(date_time_value.timestamp() as u32, Tz::UTC)
+        );
     }
 
     #[test]
@@ -547,10 +549,7 @@ mod test {
             Value::Date(u16::get_days(date_value), date_value.timezone()),
             d
         );
-        assert_eq!(
-            Value::ChronoDateTime(date_time_value),
-            dt
-        );
+        assert_eq!(Value::ChronoDateTime(date_time_value), dt);
     }
 
     #[test]

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -2,15 +2,15 @@ use std::{convert, fmt, str, sync::Arc};
 
 use chrono::prelude::*;
 use chrono_tz::Tz;
+use either::Either;
 
 use crate::{
     errors::{Error, FromSqlError, Result},
     types::{
-        Enum8, Enum16,
-        column::{Either, datetime64::to_datetime},
+        column::datetime64::to_datetime,
         decimal::Decimal,
-        value::{AppDate, AppDateTime, decode_ipv4, decode_ipv6},
-        SqlType, DateTimeType, Value,
+        value::{decode_ipv4, decode_ipv6, AppDate, AppDateTime},
+        DateTimeType, Enum16, Enum8, SqlType, Value,
     },
 };
 
@@ -378,7 +378,7 @@ impl<'a> From<ValueRef<'a>> for AppDateTime {
             ValueRef::DateTime64(x, params) => {
                 let (precision, tz) = *params;
                 to_datetime(x, precision, tz)
-            },
+            }
             _ => {
                 let from = format!("{}", SqlType::from(value.clone()));
                 panic!("Can't convert ValueRef::{} into {}.", from, "DateTime<Tz>")

--- a/tests/clickhouse.rs
+++ b/tests/clickhouse.rs
@@ -23,9 +23,9 @@ use futures_util::{
 
 use clickhouse_rs::{
     errors::Error,
+    row,
     types::{Decimal, Enum16, Enum8, FromSql},
     Block, Pool,
-    row,
 };
 use uuid::Uuid;
 use Tz::UTC;
@@ -78,10 +78,7 @@ async fn test_create_table() -> Result<(), Error> {
     c.execute(ddl).await?;
 
     if let Err(err) = c.execute(ddl).await {
-        assert_eq!(
-            "Server error",
-            &format!("{}", err)[..12]
-        );
+        assert_eq!("Server error", &format!("{}", err)[..12]);
     } else {
         panic!("should fail")
     }
@@ -235,6 +232,9 @@ async fn test_insert() -> Result<(), Error> {
         .query("SELECT * FROM clickhouse_test_insert")
         .fetch_all()
         .await?;
+
+    println!("{expected:#?}");
+    println!("{actual:#?}");
 
     assert_eq!(format!("{:?}", expected.as_ref()), format!("{:?}", &actual));
     Ok(())
@@ -396,7 +396,6 @@ async fn test_simple_selects() -> Result<(), Error> {
         .fetch_all()
         .await?;
     assert!((2_f64 - r.get::<f64, _>(0, 0)?).abs() < EPSILON);
-
 
     let expected = Block::new().column("a", vec![1_u8, 2, 3]);
     assert_eq!(expected, actual);
@@ -633,7 +632,12 @@ async fn test_nullable() -> Result<(), Error> {
             "ipv6",
             vec![Some(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff))],
         )
-        .column("uuid", vec![Some(Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap())]);
+        .column(
+            "uuid",
+            vec![Some(
+                Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap(),
+            )],
+        );
 
     let pool = Pool::new(database_url());
     let mut c = pool.get_handle().await?;
@@ -682,7 +686,10 @@ async fn test_nullable() -> Result<(), Error> {
         Some(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff))
     );
 
-    assert_eq!(uuid, Some(Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap()));
+    assert_eq!(
+        uuid,
+        Some(Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap())
+    );
 
     Ok(())
 }
@@ -777,7 +784,8 @@ async fn test_foreign_columns() -> Result<(), Error> {
 
     let pool = Pool::new(database_url());
     let mut c = pool.get_handle().await?;
-    c.execute("DROP TABLE IF EXISTS clickhouse_foreign_columns").await?;
+    c.execute("DROP TABLE IF EXISTS clickhouse_foreign_columns")
+        .await?;
     c.execute(ddl).await?;
     c.insert("clickhouse_foreign_columns", block).await?;
     let block = c.query(query).fetch_all().await?;
@@ -1100,7 +1108,10 @@ async fn test_column_iter() -> Result<(), Error> {
         .column("array", vec![vec![42_u32], Vec::new(), Vec::new()])
         .column("ipv4", vec!["127.0.0.1", "127.0.0.1", "127.0.0.1"])
         .column("ipv6", vec!["::1", "::1", "::1"])
-        .column("uuid", vec![Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap(); 3]);
+        .column(
+            "uuid",
+            vec![Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap(); 3],
+        );
 
     let pool = Pool::new(database_url());
     let mut c = pool.get_handle().await?;
@@ -1171,7 +1182,10 @@ async fn test_column_iter() -> Result<(), Error> {
         assert_eq!(ipv6_iter, vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1); 3]);
 
         let uuid_iter: Vec<_> = block.get_column("uuid")?.iter::<Uuid>()?.collect();
-        assert_eq!(uuid_iter, vec![Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap(); 3]);
+        assert_eq!(
+            uuid_iter,
+            vec![Uuid::parse_str("936da01f-9abd-4d9d-80c7-02af85c822a8").unwrap(); 3]
+        );
     }
 
     Ok(())
@@ -1290,8 +1304,7 @@ async fn test_ip_from_string() -> Result<(), Error> {
         ) ENGINE = Memory
     ";
 
-    let source_block = Block::new()
-        .column("ip_v4", vec!["192.168.2.1", "1.2.3.4"]);
+    let source_block = Block::new().column("ip_v4", vec!["192.168.2.1", "1.2.3.4"]);
 
     let pool = Pool::new(database_url());
 
@@ -1300,9 +1313,7 @@ async fn test_ip_from_string() -> Result<(), Error> {
         .execute("DROP TABLE IF EXISTS clickhouse_test_ipv4")
         .await?;
     client.execute(ddl).await?;
-    client
-        .insert("clickhouse_test_ipv4", source_block)
-        .await?;
+    client.insert("clickhouse_test_ipv4", source_block).await?;
     let block = client
         .query("SELECT ip_v4 FROM clickhouse_test_ipv4")
         .fetch_all()
@@ -1325,8 +1336,10 @@ async fn test_ipv6_from_string() -> Result<(), Error> {
         ) ENGINE = Memory
     ";
 
-    let source_block = Block::new()
-        .column("ip_v6", vec!["0001:0203:0405:0607:0809:0A0B:0C0D:0E0F", "::1", "1::"]);
+    let source_block = Block::new().column(
+        "ip_v6",
+        vec!["0001:0203:0405:0607:0809:0A0B:0C0D:0E0F", "::1", "1::"],
+    );
 
     let pool = Pool::new(database_url());
 
@@ -1335,9 +1348,7 @@ async fn test_ipv6_from_string() -> Result<(), Error> {
         .execute("DROP TABLE IF EXISTS clickhouse_test_ipv6")
         .await?;
     client.execute(ddl).await?;
-    client
-        .insert("clickhouse_test_ipv6", source_block)
-        .await?;
+    client.insert("clickhouse_test_ipv6", source_block).await?;
     let block = client
         .query("SELECT ip_v6 FROM clickhouse_test_ipv6")
         .fetch_all()
@@ -1347,7 +1358,10 @@ async fn test_ipv6_from_string() -> Result<(), Error> {
     let ip2: Ipv6Addr = block.get(1, "ip_v6")?;
     let ip3: Ipv6Addr = block.get(2, "ip_v6")?;
 
-    assert_eq!(ip1, Ipv6Addr::new(0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D, 0x0E0F));
+    assert_eq!(
+        ip1,
+        Ipv6Addr::new(0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D, 0x0E0F)
+    );
     assert_eq!(ip2, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
     assert_eq!(ip3, Ipv6Addr::new(1, 0, 0, 0, 0, 0, 0, 0));
     Ok(())
@@ -1362,8 +1376,10 @@ async fn test_ipv6_db_representation() -> Result<(), Error> {
         ) ENGINE = Memory
     ";
 
-    let source_block = Block::new()
-        .column("ip_v6", vec!["0001:0203:0405:0607:0809:0A0B:0C0D:0E0F", "::1", "1::"]);
+    let source_block = Block::new().column(
+        "ip_v6",
+        vec!["0001:0203:0405:0607:0809:0A0B:0C0D:0E0F", "::1", "1::"],
+    );
 
     let pool = Pool::new(database_url());
 
@@ -1381,7 +1397,7 @@ async fn test_ipv6_db_representation() -> Result<(), Error> {
         .await?;
 
     let ip1: &str = block.get(0, "ip_v6_str")?;
-    let ip2: &str  = block.get(1, "ip_v6_str")?;
+    let ip2: &str = block.get(1, "ip_v6_str")?;
     let ip3: &str = block.get(2, "ip_v6_str")?;
 
     assert_eq!(ip1, "1:203:405:607:809:a0b:c0d:e0f");
@@ -1400,23 +1416,31 @@ async fn test_insert_date64() -> Result<(), Error> {
         ) ENGINE = Memory
     ";
 
-    let date = chrono_tz::UTC.ymd(2020, 2, 3).and_hms_nano(13, 45, 50, 8927265);
+    let date = chrono_tz::UTC
+        .ymd(2020, 2, 3)
+        .and_hms_nano(13, 45, 50, 8927265);
     let mut block = Block::new();
-    block.push(row!{
+    block.push(row! {
         id: 1u32,
         date,
     })?;
 
-
     let pool = Pool::new(database_url());
 
     let mut client = pool.get_handle().await?;
-    client.execute("DROP TABLE IF EXISTS clickhouse_test_insert_date64").await?;
+    client
+        .execute("DROP TABLE IF EXISTS clickhouse_test_insert_date64")
+        .await?;
     client.execute(ddl).await?;
 
-    client.insert("clickhouse_test_insert_date64", &block).await?;
+    client
+        .insert("clickhouse_test_insert_date64", &block)
+        .await?;
 
-    let result = client.query("SELECT * FROM clickhouse_test_insert_date64").fetch_all().await?;
+    let result = client
+        .query("SELECT * FROM clickhouse_test_insert_date64")
+        .fetch_all()
+        .await?;
     assert_eq!(result.row_count(), 1);
 
     Ok(())
@@ -1442,17 +1466,19 @@ async fn test_simple_agg_func() -> Result<(), Error> {
     let pool = Pool::new(database_url());
 
     let mut client = pool.get_handle().await?;
-    client.execute("DROP TABLE IF EXISTS clickhouse_test_simple_agg_func").await?;
+    client
+        .execute("DROP TABLE IF EXISTS clickhouse_test_simple_agg_func")
+        .await?;
     client.execute(ddl).await?;
-    client.insert("clickhouse_test_simple_agg_func", &block).await?;
+    client
+        .insert("clickhouse_test_simple_agg_func", &block)
+        .await?;
 
-    let result = client.query("SELECT * FROM clickhouse_test_simple_agg_func").fetch_all().await?;
-    let actual: Vec<_> = result
-        .get_column("val")?
-        .iter::<i64>()?
-        .copied()
-        .collect();
+    let result = client
+        .query("SELECT * FROM clickhouse_test_simple_agg_func")
+        .fetch_all()
+        .await?;
+    let actual: Vec<_> = result.get_column("val")?.iter::<i64>()?.copied().collect();
     assert_eq!(actual, vec![6_i64, 9, 7]);
     Ok(())
 }
-


### PR DESCRIPTION
Previous implementation of the `Value` enum used a hand-crafted `Either`
enum in order to represent values that can either be null (the `Left`
variant) or non-null value (the `Right`) variant.

The problem is that this enum was not exposed in the public API. As
such, it was impossible for `clickhouse_rs` users to build
`Value::Nullable(...)` values.

This commit fixes the problem by removing the `Either` datatype from the
codebase and using the [`either`] crate instead, hence making every
variant of `Value` constructible!

[`either`]: https://docs.rs/either/1.6.1/either/index.html