### PR TITLE
Compare IP adresses properly

### DIFF
--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -79,6 +79,9 @@ impl PartialEq for Value {
             (Value::Enum16(values_a, val_a), Value::Enum16(values_b, val_b)) => {
                 *values_a == *values_b && *val_a == *val_b
             }
+            (Value::Ipv4(a), Value::Ipv4(b)) => *a == *b,
+            (Value::Ipv6(a), Value::Ipv6(b)) => *a == *b,
+            (Value::Uuid(a), Value::Uuid(b)) => *a == *b,
             _ => false,
         }
     }
@@ -339,7 +342,10 @@ value_from! {
     f32: Float32,
     f64: Float64,
 
-    Decimal: Decimal
+    Decimal: Decimal,
+
+    [u8; 4]: Ipv4,
+    [u8; 16]: Ipv6
 }
 
 impl<'a> convert::From<&'a str> for Value {
@@ -429,7 +435,8 @@ from_value! {
     i32: Int32,
     i64: Int64,
     f32: Float32,
-    f64: Float64
+    f64: Float64,
+    [u8; 4]: Ipv4
 }
 
 pub(crate) fn decode_ipv4(octets: &[u8; 4]) -> Ipv4Addr {
@@ -483,7 +490,7 @@ mod test {
     }
 
     macro_rules! test_type {
-        ( $( $k:ident : $t:ident ),* ) => {
+        ( $( $k:ident : $t:ty ),* ) => {
             $(
                 #[test]
                 fn $k() {
@@ -505,7 +512,9 @@ mod test {
         test_i64: i64,
 
         test_f32: f32,
-        test_f64: f64
+        test_f64: f64,
+
+        test_ipv4: [u8; 4]
     }
 
     #[test]


### PR DESCRIPTION
Compare IP adresses and UUID properly

The implementation of `PartialEq` for `Value` is handcrafted. It is
composed of a huge `match` expression, which aims to properly compare
each variant of the left-hand and the right-hand `Values`. The last arm
is a catchall arm, supposed to catch every case where both variant does
not match.

The problem is that no match arm in the said expression handles the
`Ipv4`, `Ipv6` and `Uuid` variants. As such, two IP addresses are always
considered as not equal. Similarly, two UUIDs are always considered as
not equal.

This commit adds three missing arms, which adds proper IP address
comparison as well as proper UUID comparison.