### PR TITLE
Add support for Array(Enum8)

### DIFF
--- a/src/types/column/mod.rs
+++ b/src/types/column/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt, marker,
+    marker,
     net::{Ipv4Addr, Ipv6Addr},
     ops,
     sync::Arc,

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -187,8 +187,10 @@ from_sql_vec_impl! {
     &'a [u8]: SqlType::String => |v| v.as_bytes(),
     Vec<u8>: SqlType::String => |v| v.as_bytes().map(<[u8]>::to_vec),
     Date<Tz>: SqlType::Date => |z| Ok(z.into()),
-    DateTime<Tz>: SqlType::DateTime(_) => |z| Ok(z.into())
+    DateTime<Tz>: SqlType::DateTime(_) => |z| Ok(z.into()),
+    Enum8: SqlType::Enum8(_) => |z| Ok(z.into())
 }
+
 
 impl<'a> FromSql<'a> for Vec<u8> {
     fn from_sql(value: ValueRef<'a>) -> FromSqlResult<Self> {
@@ -204,6 +206,8 @@ impl<'a> FromSql<'a> for Vec<u8> {
         }
     }
 }
+
+
 
 macro_rules! from_sql_vec_impl {
     ( $( $t:ident: $k:ident ),* ) => {

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -371,6 +371,16 @@ impl<'a> From<ValueRef<'a>> for AppDate {
     }
 }
 
+impl<'a> From<ValueRef<'a>> for Enum8 {
+    fn from(value: ValueRef<'a>) -> Self {
+        if let ValueRef::Enum8(_,b) = value {
+            return b
+        }
+        let from = format!("{}", SqlType::from(value.clone()));
+        panic!("Can't convert ValueRef::{} into {}.", from, stringify!($t))
+    }
+}
+
 impl<'a> From<ValueRef<'a>> for AppDateTime {
     fn from(value: ValueRef<'a>) -> Self {
         match value {


### PR DESCRIPTION
Adds support for inserting a Vec<Enum8> in much the same way that arrays are supported for other data types.

This can also be replicated for Enum16

