### PR TITLE
Fix "Unsupported column type DateTime" error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ features = ["std"]
 
 [dev-dependencies]
 env_logger = "^0.9"
+pretty_assertions = "1.3.0"
 rand = "^0.8"
 
 [dev-dependencies.tokio]


### PR DESCRIPTION
This change fixes https://github.com/suharev7/clickhouse-rs/issues/159. I've added two tests checking inserting and selecting data from columns of type DateTime (with and without timezone) and DateTime64 (with and without timezone).

Let me know if I should remove pretty_assertions dev dependency. 