### PR TITLE
feat: I256 & `ethabi::ethereum_types` from sql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ uuid = "0.8.1"
 combine = "4.2.3"
 percent-encoding = "2.1.0"
 either = "1.6.1"
+ethnum = "1.3.2"
+ethabi = "18.0.0"
 
 [dependencies.futures-util]
 version = "0.3.16"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
-use std::{env, error::Error};
 use clickhouse_rs::{row, types::Block, Pool};
 use futures_util::StreamExt;
+use std::{env, error::Error};
 
 async fn execute(database_url: String) -> Result<(), Box<dyn Error>> {
     env::set_var("RUST_LOG", "clickhouse_rs=debug");
@@ -49,9 +49,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(all(feature = "tokio_io", feature = "tls"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| {
-        "tcp://localhost:9440?secure=true&skip_verify=true".into()
-    });
+    let database_url = env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "tcp://localhost:9440?secure=true&skip_verify=true".into());
     execute(database_url).await
 }
 

--- a/src/binary/parser.rs
+++ b/src/binary/parser.rs
@@ -20,7 +20,7 @@ pub(crate) struct Parser<T> {
 /// you normally do not use this directly as it's already done for you by
 /// the client but in some more complex situations it might be useful to be
 /// able to parse the clickhouse responses.
-impl<'a, T: Read> Parser<T> {
+impl<T: Read> Parser<T> {
     /// Creates a new parser that parses the data behind the reader.  More
     /// than one value can be behind the reader in which case the parser can
     /// be invoked multiple times.  In other words: the stream does not have

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -66,10 +66,7 @@ pub enum UrlError {
     #[error("Invalid or incomplete connection URL")]
     Invalid,
 
-    #[error(
-        "Invalid value `{}' for connection URL parameter `{}'",
-        value, param
-    )]
+    #[error("Invalid value `{}' for connection URL parameter `{}'", value, param)]
     InvalidParamValue { param: String, value: String },
 
     #[error("URL parse error: {}", _0)]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,8 +1,5 @@
-pub(crate) use self::{
-    stream::Stream,
-    transport::ClickhouseTransport,
-};
+pub(crate) use self::{stream::Stream, transport::ClickhouseTransport};
 
 mod read_to_end;
-pub(crate) mod transport;
 pub(crate) mod stream;
+pub(crate) mod transport;

--- a/src/io/read_to_end.rs
+++ b/src/io/read_to_end.rs
@@ -6,9 +6,7 @@ use std::{
 
 use futures_util::ready;
 
-use crate::{
-    io::Stream as InnerStream,
-};
+use crate::io::Stream as InnerStream;
 
 struct Guard<'a> {
     buf: &'a mut Vec<u8>,

--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -3,8 +3,12 @@ use std::{
     io::{self, Cursor},
     pin::Pin,
     ptr,
+    sync::{
+        self,
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     task::{self, Poll},
-    sync::{self, Arc, atomic::{AtomicBool, Ordering}},
 };
 
 use chrono_tz::Tz;
@@ -16,8 +20,8 @@ use crate::{
     binary::Parser,
     errors::{DriverError, Error, Result},
     io::{read_to_end::read_to_end, Stream as InnerStream},
+    pool::{Inner, Pool},
     types::{Block, Cmd, Packet},
-    pool::{Pool, Inner},
 };
 use futures_core::Stream;
 use futures_util::StreamExt;

--- a/src/pool/futures/get_handle.rs
+++ b/src/pool/futures/get_handle.rs
@@ -1,5 +1,5 @@
-use std::{future::Future, pin::Pin};
 use std::task::{Context, Poll};
+use std::{future::Future, pin::Pin};
 
 use pin_project::pin_project;
 

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,7 +1,8 @@
 use std::{
-    fmt, mem, pin::Pin,
-    sync::Arc,
+    fmt, mem,
+    pin::Pin,
     sync::atomic::{self, Ordering},
+    sync::Arc,
     task::{Context, Poll, Waker},
 };
 
@@ -9,9 +10,9 @@ use futures_util::future::BoxFuture;
 use log::error;
 
 use crate::{
-    Client,
-    ClientHandle,
-    errors::Result, types::{IntoOptions, OptionsSource},
+    errors::Result,
+    types::{IntoOptions, OptionsSource},
+    Client, ClientHandle,
 };
 
 pub use self::futures::GetHandle;
@@ -215,16 +216,16 @@ impl Pool {
             match new.poll_unpin(cx) {
                 Poll::Ready(Ok(client)) => {
                     self.inner.idle.push(client).unwrap();
-                },
+                }
                 Poll::Pending => {
                     // NOTE: it is okay to drop the construction task
                     // because another construction will be attempted
                     // later in Pool::poll
                     let _ = self.inner.new.push(new);
-                },
+                }
                 Poll::Ready(Err(err)) => {
                     return Err(err);
-                },
+                }
             }
         }
 
@@ -294,7 +295,7 @@ mod test {
 
     use futures_util::future;
 
-    use crate::{Block, errors::Result, Options, test_misc::DATABASE_URL};
+    use crate::{errors::Result, test_misc::DATABASE_URL, Block, Options};
 
     use super::Pool;
     use url::Url;
@@ -404,7 +405,8 @@ mod test {
 
     #[test]
     fn test_get_addr() {
-        let options = Options::from_str("tcp://host1:9000?alt_hosts=host2:9000,host3:9000").unwrap();
+        let options =
+            Options::from_str("tcp://host1:9000?alt_hosts=host2:9000,host3:9000").unwrap();
         let pool = Pool::new(options);
 
         assert_eq!(pool.get_addr(), &Url::from_str("tcp://host1:9000").unwrap());

--- a/src/types/block/compressed.rs
+++ b/src/types/block/compressed.rs
@@ -1,4 +1,9 @@
-use std::{io, io::Read, mem, os::raw::{c_int, c_char}};
+use std::{
+    io,
+    io::Read,
+    mem,
+    os::raw::{c_char, c_int},
+};
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use clickhouse_rs_cityhash_sys::{city_hash_128, UInt128};

--- a/src/types/block/mod.rs
+++ b/src/types/block/mod.rs
@@ -445,8 +445,8 @@ fn text_cells<K: ColumnType>(data: &Column<K>) -> Vec<String> {
 
 #[cfg(test)]
 mod test {
-    use crate::row;
     use super::*;
+    use crate::row;
 
     #[test]
     fn test_write_default() {
@@ -598,9 +598,11 @@ mod test {
     fn test_insert_str_array() {
         let expected: Vec<String> = vec!["A".into(), "B".into()];
         let mut block = Block::new();
-        block.push(row! {
-              tags: expected.clone(),
-        }).unwrap();
+        block
+            .push(row! {
+                  tags: expected.clone(),
+            })
+            .unwrap();
 
         let actual: Vec<String> = block.get(0, 0).unwrap();
         assert_eq!(actual, expected);

--- a/src/types/cmd.rs
+++ b/src/types/cmd.rs
@@ -4,7 +4,7 @@ use crate::{
     binary::{protocol, Encoder},
     client_info,
     errors::Result,
-    types::{Context, Query, Simple, Options},
+    types::{Context, Options, Query, Simple},
     Block,
 };
 
@@ -86,7 +86,7 @@ fn encode_query(query: &Query, context: &Context) -> Result<Vec<u8>> {
         let hostname = &context.hostname;
         encoder.uvarint(1);
         encoder.string("");
-        encoder.string(&query.get_id()); // initial_query_id;
+        encoder.string(query.get_id()); // initial_query_id;
         encoder.string("[::ffff:127.0.0.1]:0");
         encoder.uvarint(1); // iface type TCP;
         encoder.string(hostname);
@@ -100,7 +100,9 @@ fn encode_query(query: &Query, context: &Context) -> Result<Vec<u8>> {
 
     let options = context.options.get()?;
 
-    let settings_format = if context.server_info.revision >= protocol::DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS {
+    let settings_format = if context.server_info.revision
+        >= protocol::DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS
+    {
         SettingsBinaryFormat::Strings
     } else {
         SettingsBinaryFormat::Old
@@ -118,14 +120,13 @@ fn encode_query(query: &Query, context: &Context) -> Result<Vec<u8>> {
 
     let options = context.options.get()?;
 
-    encoder.string(&query.get_sql());
+    encoder.string(query.get_sql());
     Block::<Simple>::default().send_data(&mut encoder, options.compression);
 
     Ok(encoder.get_buffer())
 }
 
 fn serialize_settings(encoder: &mut Encoder, options: &Options, format: SettingsBinaryFormat) {
-
     if let Some(level) = options.readonly {
         encoder.string("readonly");
         if format >= SettingsBinaryFormat::Strings {

--- a/src/types/column/array.rs
+++ b/src/types/column/array.rs
@@ -6,7 +6,11 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        column::{column_data::{BoxColumnData, ArcColumnData}, list::List, ArcColumnWrapper, ColumnData},
+        column::{
+            column_data::{ArcColumnData, BoxColumnData},
+            list::List,
+            ArcColumnWrapper, ColumnData,
+        },
         SqlType, Value, ValueRef,
     },
 };
@@ -31,7 +35,8 @@ impl ArrayColumnData {
             0 => 0,
             _ => offsets.at(rows - 1) as usize,
         };
-        let inner = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, size, tz)?;
+        let inner =
+            <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, size, tz)?;
 
         Ok(ArrayColumnData { inner, offsets })
     }
@@ -101,7 +106,12 @@ impl ColumnData for ArrayColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        props: u32,
+    ) -> Result<()> {
         if level == self.sql_type().level() {
             *pointers[0] = self.offsets.as_ptr() as *const u8;
             *(pointers[1] as *mut usize) = self.offsets.len();
@@ -116,8 +126,8 @@ impl ColumnData for ArrayColumnData {
             if let Some(inner) = self.inner.cast_to(&self.inner, inner_target) {
                 return Some(Arc::new(ArrayColumnData {
                     inner,
-                    offsets: self.offsets.clone()
-                }))
+                    offsets: self.offsets.clone(),
+                }));
             }
         }
         None
@@ -129,7 +139,7 @@ mod test {
     use std::io::Cursor;
 
     use super::*;
-    use crate::{Block, types::Simple};
+    use crate::{types::Simple, Block};
 
     #[test]
     fn test_write_and_read() {

--- a/src/types/column/chrono_datetime.rs
+++ b/src/types/column/chrono_datetime.rs
@@ -6,14 +6,13 @@ use crate::{
     binary::Encoder,
     errors::Result,
     types::{
-        SqlType,
-        DateTimeType,
         column::{
-            column_data::{BoxColumnData, ArcColumnData, ColumnData},
+            column_data::{ArcColumnData, BoxColumnData, ColumnData},
             datetime64::from_datetime,
             nullable::NullableColumnData,
             ArcColumnWrapper, ColumnFrom, ColumnWrapper, Value, ValueRef,
-        }
+        },
+        DateTimeType, SqlType,
     },
 };
 
@@ -113,7 +112,12 @@ impl ColumnData for ChronoDateTimeColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         *pointers[0] = self.data.as_ptr() as *const u8;
         *pointers[1] = &self.tz as *const Tz as *const u8;
@@ -149,7 +153,7 @@ pub(crate) fn get_date_slice<'a>(column: &dyn ColumnData) -> Result<&'a [DateTim
                 &mut len as *mut usize as *mut *const u8,
             ],
             0,
-            0
+            0,
         )?;
         assert_ne!(data, ptr::null());
         assert_ne!(tz, ptr::null());
@@ -202,7 +206,12 @@ impl ColumnData for ChronoDateTimeAdapter {
         unimplemented!()
     }
 
-    unsafe fn get_internal(&self, _pointers: &[*mut *const u8], _level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        _pointers: &[*mut *const u8],
+        _level: u8,
+        _props: u32,
+    ) -> Result<()> {
         unimplemented!()
     }
 }

--- a/src/types/column/column_data.rs
+++ b/src/types/column/column_data.rs
@@ -19,7 +19,12 @@ pub trait ColumnData {
 
     fn clone_instance(&self) -> BoxColumnData;
 
-    unsafe fn get_internal(&self, _pointers: &[*mut *const u8], _level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        _pointers: &[*mut *const u8],
+        _level: u8,
+        _props: u32,
+    ) -> Result<()> {
         Err(Error::FromSql(FromSqlError::UnsupportedOperation))
     }
 

--- a/src/types/column/concat.rs
+++ b/src/types/column/concat.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use crate::{
     binary::Encoder,
-    errors::{Result, Error, FromSqlError},
+    errors::{Error, FromSqlError, Result},
     types::{SqlType, Value, ValueRef},
 };
 
@@ -66,7 +66,12 @@ impl ColumnData for ConcatColumnData {
         unimplemented!()
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         if level == 0xff {
             *pointers[0] = &self.data as *const Vec<ArcColumnData> as *mut u8;
             Ok(())

--- a/src/types/column/date.rs
+++ b/src/types/column/date.rs
@@ -197,7 +197,12 @@ where
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         *pointers[0] = self.data.as_ptr() as *const u8;
         *pointers[1] = &self.tz as *const Tz as *const u8;

--- a/src/types/column/datetime64.rs
+++ b/src/types/column/datetime64.rs
@@ -5,10 +5,11 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        SqlType, DateTimeType, Value, ValueRef,
         column::{
-            column_data::{BoxColumnData, ColumnData}, list::List,
-        }
+            column_data::{BoxColumnData, ColumnData},
+            list::List,
+        },
+        DateTimeType, SqlType, Value, ValueRef,
     },
 };
 
@@ -76,7 +77,12 @@ impl ColumnData for DateTime64ColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         let (precision, tz) = &self.params;
         *pointers[0] = self.data.as_ptr() as *const u8;

--- a/src/types/column/decimal.rs
+++ b/src/types/column/decimal.rs
@@ -188,7 +188,12 @@ impl ColumnData for DecimalColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         self.inner.get_internal(pointers, 0, 0)?;
         *(pointers[2] as *mut NoBits) = self.nobits;

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -7,6 +7,7 @@ use combine::{
     parser::char::{digit, spaces, string},
     sep_by1, token, Parser,
 };
+use ethnum::I256;
 
 use crate::{
     binary::ReadEx,
@@ -71,6 +72,7 @@ impl dyn ColumnData {
             "Int64" | "BigInt" => W::wrap(VectorColumnData::<i64>::load(reader, size)?),
             "Float32" | "Float" => W::wrap(VectorColumnData::<f32>::load(reader, size)?),
             "Float64" | "Double" => W::wrap(VectorColumnData::<f64>::load(reader, size)?),
+            "Int256" => W::wrap(VectorColumnData::<I256>::load(reader, size)?),
             "String" | "Char" | "Varchar" | "Text" | "TinyText" | "MediumText" | "LongText" | "Blob" | "TinyBlob" | "MediumBlob" | "LongBlob" => W::wrap(StringColumnData::load(reader, size)?),
             "Date" => W::wrap(DateColumnData::<u16>::load(reader, size, tz)?),
             "IPv4" => W::wrap(IpColumnData::<Ipv4>::load(reader, size)?),
@@ -123,6 +125,7 @@ impl dyn ColumnData {
             SqlType::Int16 => W::wrap(VectorColumnData::<i16>::with_capacity(capacity)),
             SqlType::Int32 => W::wrap(VectorColumnData::<i32>::with_capacity(capacity)),
             SqlType::Int64 => W::wrap(VectorColumnData::<i64>::with_capacity(capacity)),
+            SqlType::Int256 => W::wrap(VectorColumnData::<I256>::with_capacity(capacity)),
             SqlType::String => W::wrap(StringColumnData::with_capacity(capacity)),
             SqlType::FixedString(len) => {
                 W::wrap(FixedStringColumnData::with_capacity(capacity, len))
@@ -202,13 +205,13 @@ impl dyn ColumnData {
             }),
             SqlType::Map(k, v) => W::wrap(MapColumnData {
                 keys: <dyn ColumnData>::from_type::<ArcColumnWrapper>(
-                    k.clone().into(),
+                    k.clone(),
                     timezone,
                     capacity,
                 )?,
                 offsets: List::with_capacity(capacity),
                 values: <dyn ColumnData>::from_type::<ArcColumnWrapper>(
-                    v.clone().into(),
+                    v.clone(),
                     timezone,
                     capacity,
                 )?,

--- a/src/types/column/fixed_string.rs
+++ b/src/types/column/fixed_string.rs
@@ -4,8 +4,8 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        column::column_data::BoxColumnData, from_sql::*, Column, SqlType, Value,
-        ValueRef, ColumnType
+        column::column_data::BoxColumnData, from_sql::*, Column, ColumnType, SqlType, Value,
+        ValueRef,
     },
 };
 
@@ -83,7 +83,12 @@ impl ColumnData for FixedStringColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         *pointers[0] = self.buffer.as_ptr() as *const u8;
         *(pointers[1] as *mut usize) = self.len();

--- a/src/types/column/ip.rs
+++ b/src/types/column/ip.rs
@@ -9,7 +9,7 @@ use crate::{
     errors::Result,
     types::{
         column::{column_data::BoxColumnData, nullable::NullableColumnData, ColumnWrapper},
-        SqlType, Value, ValueRef
+        SqlType, Value, ValueRef,
     },
 };
 
@@ -45,7 +45,7 @@ impl IpVersion for Ipv4 {
     #[inline(always)]
     fn push(inner: &mut Vec<u8>, value: Value) {
         if let Value::Ipv4(v) = value {
-            inner.extend(&v);
+            inner.extend(v);
         } else {
             panic!();
         }
@@ -73,7 +73,7 @@ impl IpVersion for Ipv6 {
     #[inline(always)]
     fn push(inner: &mut Vec<u8>, value: Value) {
         if let Value::Ipv6(v) = value {
-            inner.extend(&v);
+            inner.extend(v);
         } else {
             panic!();
         }
@@ -101,7 +101,7 @@ impl IpVersion for Uuid {
     #[inline(always)]
     fn push(inner: &mut Vec<u8>, value: Value) {
         if let Value::Uuid(v) = value {
-            inner.extend(&v);
+            inner.extend(v);
         } else {
             panic!();
         }
@@ -121,7 +121,7 @@ impl ColumnFrom for Vec<Ipv4Addr> {
         for ip in data {
             let mut buffer = ip.octets();
             buffer.reverse();
-            inner.extend(&buffer);
+            inner.extend(buffer);
         }
 
         W::wrap(IpColumnData::<Ipv4> {
@@ -135,7 +135,7 @@ impl ColumnFrom for Vec<Ipv6Addr> {
     fn column_from<W: ColumnWrapper>(data: Self) -> W::Wrapper {
         let mut inner = Vec::with_capacity(data.len());
         for ip in data {
-            inner.extend(&ip.octets());
+            inner.extend(ip.octets());
         }
 
         W::wrap(IpColumnData::<Ipv6> {
@@ -152,7 +152,7 @@ impl ColumnFrom for Vec<uuid::Uuid> {
             let mut buffer = *uuid.as_bytes();
             buffer[..8].reverse();
             buffer[8..].reverse();
-            inner.extend(&buffer);
+            inner.extend(buffer);
         }
 
         W::wrap(IpColumnData::<Uuid> {
@@ -171,13 +171,13 @@ impl ColumnFrom for Vec<Option<Ipv4Addr>> {
         for ip in source {
             match ip {
                 None => {
-                    inner.extend(&[0; 4]);
+                    inner.extend([0; 4]);
                     nulls.push(1);
                 }
                 Some(ip) => {
                     let mut buffer = ip.octets();
                     buffer.reverse();
-                    inner.extend(&buffer);
+                    inner.extend(buffer);
                     nulls.push(0);
                 }
             }
@@ -203,11 +203,11 @@ impl ColumnFrom for Vec<Option<Ipv6Addr>> {
         for ip in source {
             match ip {
                 None => {
-                    inner.extend(&[0; 16]);
+                    inner.extend([0; 16]);
                     nulls.push(1);
                 }
                 Some(ip) => {
-                    inner.extend(&ip.octets());
+                    inner.extend(ip.octets());
                     nulls.push(0);
                 }
             }
@@ -233,14 +233,14 @@ impl ColumnFrom for Vec<Option<uuid::Uuid>> {
         for uuid in source {
             match uuid {
                 None => {
-                    inner.extend(&[0; 16]);
+                    inner.extend([0; 16]);
                     nulls.push(1);
                 }
                 Some(uuid) => {
                     let mut buffer = *uuid.as_bytes();
                     buffer[..8].reverse();
                     buffer[8..].reverse();
-                    inner.extend(&buffer);
+                    inner.extend(buffer);
                     nulls.push(0);
                 }
             }
@@ -313,7 +313,12 @@ impl<V: IpVersion> ColumnData for IpColumnData<V> {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         *pointers[0] = &self.inner as *const Vec<u8> as *const u8;
         Ok(())

--- a/src/types/column/iter/mod.rs
+++ b/src/types/column/iter/mod.rs
@@ -1192,7 +1192,7 @@ mod test {
         let mut aa = HashMap::new();
 
         for a in &actual[0] {
-            aa.insert(a.0.clone(), *a.1.clone());
+            aa.insert(<&[u8]>::clone(a.0), *<&u8>::clone(a.1));
         }
 
         let mut expected = HashMap::new();

--- a/src/types/column/mod.rs
+++ b/src/types/column/mod.rs
@@ -375,7 +375,7 @@ impl<K: ColumnType> Column<K> {
                     let mut buffer = [0_u8; 4];
                     buffer.copy_from_slice(&ip.octets());
                     buffer.reverse();
-                    inner.extend(&buffer);
+                    inner.extend(buffer);
                 }
 
                 let data = Arc::new(IpColumnData::<Ipv4> {
@@ -397,7 +397,7 @@ impl<K: ColumnType> Column<K> {
                 for i in 0..n {
                     let source = self.at(i).as_str().unwrap();
                     let ip: Ipv6Addr = source.parse().unwrap();
-                    inner.extend(&ip.octets());
+                    inner.extend(ip.octets());
                 }
 
                 let data = Arc::new(IpColumnData::<Ipv6> {
@@ -454,7 +454,12 @@ impl<K: ColumnType> Column<K> {
         }
     }
 
-    pub(crate) unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, props: u32) -> Result<()> {
+    pub(crate) unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        props: u32,
+    ) -> Result<()> {
         self.data.get_internal(pointers, level, props)
     }
 }

--- a/src/types/column/nullable.rs
+++ b/src/types/column/nullable.rs
@@ -90,7 +90,12 @@ impl ColumnData for NullableColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        props: u32,
+    ) -> Result<()> {
         if level == self.sql_type().level() {
             *pointers[0] = self.nulls.as_ptr();
             *(pointers[1] as *mut usize) = self.len();

--- a/src/types/column/numeric.rs
+++ b/src/types/column/numeric.rs
@@ -7,7 +7,7 @@ use crate::{
         column::{
             array::ArrayColumnData, nullable::NullableColumnData, ArcColumnWrapper, ColumnWrapper,
         },
-        Marshal, SqlType, StatBuffer, Unmarshal, Value, ValueRef, HasSqlType,
+        HasSqlType, Marshal, SqlType, StatBuffer, Unmarshal, Value, ValueRef,
     },
 };
 
@@ -208,6 +208,7 @@ where
             Value::Int16(x) => ValueRef::Int16(x),
             Value::Int32(x) => ValueRef::Int32(x),
             Value::Int64(x) => ValueRef::Int64(x),
+            Value::Int256(x) => ValueRef::Int256(x),
 
             Value::Float32(x) => ValueRef::Float32(x),
             Value::Float64(x) => ValueRef::Float64(x),
@@ -222,7 +223,12 @@ where
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         *pointers[0] = self.data.as_ptr() as *const u8;
         *(pointers[1] as *mut usize) = self.len();

--- a/src/types/column/simple_agg_func.rs
+++ b/src/types/column/simple_agg_func.rs
@@ -2,8 +2,11 @@ use crate::{
     binary::{Encoder, ReadEx},
     errors::Result,
     types::{
-        column::{column_data::{BoxColumnData, ArcColumnData}, ArcColumnWrapper, ColumnData},
-        SqlType, Value, ValueRef, SimpleAggFunc,
+        column::{
+            column_data::{ArcColumnData, BoxColumnData},
+            ArcColumnWrapper, ColumnData,
+        },
+        SimpleAggFunc, SqlType, Value, ValueRef,
     },
 };
 
@@ -23,7 +26,8 @@ impl SimpleAggregateFunctionColumnData {
         size: usize,
         tz: Tz,
     ) -> Result<Self> {
-        let inner = <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, size, tz)?;
+        let inner =
+            <dyn ColumnData>::load_data::<ArcColumnWrapper, _>(reader, type_name, size, tz)?;
         Ok(SimpleAggregateFunctionColumnData { inner, func })
     }
 }
@@ -58,7 +62,12 @@ impl ColumnData for SimpleAggregateFunctionColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        props: u32,
+    ) -> Result<()> {
         self.inner.get_internal(pointers, level, props)
     }
 
@@ -68,7 +77,7 @@ impl ColumnData for SimpleAggregateFunctionColumnData {
                 return Some(Arc::new(SimpleAggregateFunctionColumnData {
                     inner,
                     func: *func,
-                }))
+                }));
             }
         }
         None

--- a/src/types/column/string.rs
+++ b/src/types/column/string.rs
@@ -194,7 +194,12 @@ impl ColumnData for StringColumnData {
         })
     }
 
-    unsafe fn get_internal(&self, pointers: &[*mut *const u8], level: u8, _props: u32) -> Result<()> {
+    unsafe fn get_internal(
+        &self,
+        pointers: &[*mut *const u8],
+        level: u8,
+        _props: u32,
+    ) -> Result<()> {
         assert_eq!(level, 0);
         *pointers[0] = &self.pool as *const StringPool as *const u8;
         *(pointers[1] as *mut usize) = self.len();

--- a/src/types/date_converter.rs
+++ b/src/types/date_converter.rs
@@ -1,7 +1,7 @@
 use chrono::{prelude::*, Date};
 use chrono_tz::Tz;
 
-use crate::types::{SqlType, Value, ValueRef, DateTimeType};
+use crate::types::{DateTimeType, SqlType, Value, ValueRef};
 
 pub trait DateConverter {
     fn to_date(&self, tz: Tz) -> ValueRef<'static>;

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -37,6 +37,7 @@ pub(crate) enum NoBits {
 }
 
 /// Provides arbitrary-precision floating point decimal.
+#[allow(clippy::derive_hash_xor_eq)]
 #[derive(Clone, Hash)]
 pub struct Decimal {
     pub(crate) underlying: i64,

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
 // TODO Using strings as a keys
+#[allow(clippy::derive_hash_xor_eq)]
 #[derive(Clone, Copy, Default, Hash)]
 pub struct Enum8(pub(crate) i8);
 
+#[allow(clippy::derive_hash_xor_eq)]
 #[derive(Clone, Copy, Default, Hash)]
 pub struct Enum16(pub(crate) i16);
 

--- a/src/types/marshal.rs
+++ b/src/types/marshal.rs
@@ -1,3 +1,5 @@
+use ethnum::I256;
+
 pub trait Marshal {
     fn marshal(&self, scratch: &mut [u8]);
 }
@@ -71,6 +73,12 @@ impl Marshal for i64 {
         scratch[5] = (self >> 40) as u8;
         scratch[6] = (self >> 48) as u8;
         scratch[7] = (self >> 56) as u8;
+    }
+}
+
+impl Marshal for I256 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        scratch[..].copy_from_slice(&self.to_be_bytes());
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,9 +1,10 @@
+#![allow(deprecated)]
 use std::{borrow::Cow, collections::HashMap, fmt, mem, pin::Pin, str::FromStr, sync::Mutex};
 
 use chrono::prelude::*;
 use chrono_tz::Tz;
+use ethnum::I256;
 use hostname::get;
-
 use lazy_static::lazy_static;
 
 use crate::errors::ServerError;
@@ -44,6 +45,7 @@ mod cmd;
 
 mod date_converter;
 mod query;
+
 pub(crate) mod query_result;
 
 mod decimal;
@@ -188,6 +190,7 @@ has_sql_type! {
     i16: SqlType::Int16,
     i32: SqlType::Int32,
     i64: SqlType::Int64,
+    I256: SqlType::Int256,
     &str: SqlType::String,
     String: SqlType::String,
     f32: SqlType::Float32,
@@ -196,17 +199,13 @@ has_sql_type! {
     DateTime<Tz>: SqlType::DateTime(DateTimeType::DateTime32)
 }
 
-
 impl<K, V> HasSqlType for HashMap<K, V>
 where
     K: HasSqlType,
     V: HasSqlType,
 {
     fn get_sql_type() -> SqlType {
-        SqlType::Map(
-            K::get_sql_type().into(),
-            V::get_sql_type().into(),
-        )
+        SqlType::Map(K::get_sql_type().into(), V::get_sql_type().into())
     }
 }
 
@@ -296,6 +295,7 @@ pub enum SqlType {
     Int16,
     Int32,
     Int64,
+    Int256,
     String,
     FixedString(usize),
     Float32,
@@ -329,6 +329,7 @@ impl From<SqlType> for &'static SqlType {
             SqlType::Int16 => &SqlType::Int16,
             SqlType::Int32 => &SqlType::Int32,
             SqlType::Int64 => &SqlType::Int64,
+            SqlType::Int256 => &SqlType::Int256,
             SqlType::String => &SqlType::String,
             SqlType::Float32 => &SqlType::Float32,
             SqlType::Float64 => &SqlType::Float64,
@@ -361,6 +362,7 @@ impl SqlType {
             SqlType::Int16 => "Int16".into(),
             SqlType::Int32 => "Int32".into(),
             SqlType::Int64 => "Int64".into(),
+            SqlType::Int256 => "Int256".into(),
             SqlType::String => "String".into(),
             SqlType::FixedString(str_len) => format!("FixedString({})", str_len).into(),
             SqlType::Float32 => "Float32".into(),

--- a/src/types/query_result/mod.rs
+++ b/src/types/query_result/mod.rs
@@ -1,4 +1,3 @@
-use std::{marker::PhantomData, sync::Arc};
 use futures_util::stream::BoxStream;
 use futures_util::{
     future,
@@ -6,10 +5,11 @@ use futures_util::{
     TryStreamExt,
 };
 use log::info;
+use std::{marker::PhantomData, sync::Arc};
 
 use crate::{
-    try_opt,
     errors::Result,
+    try_opt,
     types::{
         block::BlockRef, query_result::stream_blocks::BlockStream, Block, Cmd, Complex, Query, Row,
         Rows, Simple,
@@ -17,13 +17,13 @@ use crate::{
     with_timeout, ClientHandle,
 };
 
-pub(crate) mod stream_blocks;
-
 /// Result of a query or statement execution.
 pub struct QueryResult<'a> {
     pub(crate) client: &'a mut ClientHandle,
     pub(crate) query: Query,
 }
+
+pub(crate) mod stream_blocks;
 
 impl<'a> QueryResult<'a> {
     /// Fetch data from table. It returns a block that contains all rows.

--- a/src/types/query_result/stream_blocks.rs
+++ b/src/types/query_result/stream_blocks.rs
@@ -37,7 +37,11 @@ impl<'a> Drop for BlockStream<'a> {
 }
 
 impl<'a> BlockStream<'a> {
-    pub(crate) fn new(client: &mut ClientHandle, inner: PacketStream, skip_first_block: bool) -> BlockStream {
+    pub(crate) fn new(
+        client: &mut ClientHandle,
+        inner: PacketStream,
+        skip_first_block: bool,
+    ) -> BlockStream {
         BlockStream {
             client,
             inner,
@@ -78,7 +82,7 @@ impl<'a> Stream for BlockStream<'a> {
                 Packet::ProfileInfo(_) | Packet::Progress(_) => {}
                 Packet::Exception(exception) => {
                     self.eof = true;
-                    return Poll::Ready(Some(Err(Error::Server(exception))))
+                    return Poll::Ready(Some(Err(Error::Server(exception))));
                 }
                 Packet::Block(block) => {
                     self.block_index += 1;

--- a/src/types/stat_buffer.rs
+++ b/src/types/stat_buffer.rs
@@ -1,4 +1,5 @@
 use crate::types::SqlType;
+use ethnum::I256;
 
 pub trait StatBuffer {
     type Buffer: AsMut<[u8]> + AsRef<[u8]> + Copy + Sync;
@@ -99,6 +100,18 @@ impl StatBuffer for i64 {
 
     fn sql_type() -> SqlType {
         SqlType::Int64
+    }
+}
+
+impl StatBuffer for I256 {
+    type Buffer = [u8; 32];
+
+    fn buffer() -> Self::Buffer {
+        [0; 32]
+    }
+
+    fn sql_type() -> SqlType {
+        SqlType::Int256
     }
 }
 

--- a/src/types/unmarshal.rs
+++ b/src/types/unmarshal.rs
@@ -1,3 +1,5 @@
+use ethnum::I256;
+
 pub trait Unmarshal<T: Copy> {
     fn unmarshal(scratch: &[u8]) -> T;
 }
@@ -67,6 +69,16 @@ impl Unmarshal<i64> for i64 {
             | Self::from(scratch[5]) << 40
             | Self::from(scratch[6]) << 48
             | Self::from(scratch[7]) << 56
+    }
+}
+
+impl Unmarshal<I256> for I256 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        I256::from_be_bytes(
+            scratch
+                .try_into()
+                .unwrap_or_else(|e| panic!("Error `{e}` on Unmarshal I256 from `{scratch:?}`.")),
+        )
     }
 }
 

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -5,6 +5,7 @@ use std::{convert, fmt, str, sync::Arc};
 use chrono::prelude::*;
 use chrono_tz::Tz;
 use either::Either;
+use ethnum::I256;
 
 use crate::{
     errors::{Error, FromSqlError, Result},
@@ -28,6 +29,7 @@ pub enum ValueRef<'a> {
     Int16(i16),
     Int32(i32),
     Int64(i64),
+    Int256(I256),
     String(&'a [u8]),
     Float32(f32),
     Float64(f64),
@@ -128,6 +130,7 @@ impl<'a> fmt::Display for ValueRef<'a> {
             ValueRef::Int16(v) => fmt::Display::fmt(v, f),
             ValueRef::Int32(v) => fmt::Display::fmt(v, f),
             ValueRef::Int64(v) => fmt::Display::fmt(v, f),
+            ValueRef::Int256(v) => fmt::Display::fmt(v, f),
             ValueRef::String(v) => match str::from_utf8(v) {
                 Ok(s) => fmt::Display::fmt(s, f),
                 Err(_) => write!(f, "{:?}", *v),
@@ -202,6 +205,7 @@ impl<'a> convert::From<ValueRef<'a>> for SqlType {
             ValueRef::Int16(_) => SqlType::Int16,
             ValueRef::Int32(_) => SqlType::Int32,
             ValueRef::Int64(_) => SqlType::Int64,
+            ValueRef::Int256(_) => SqlType::Int256,
             ValueRef::String(_) => SqlType::String,
             ValueRef::Float32(_) => SqlType::Float32,
             ValueRef::Float64(_) => SqlType::Float64,
@@ -267,6 +271,7 @@ impl<'a> From<ValueRef<'a>> for Value {
             ValueRef::Int16(v) => Value::Int16(v),
             ValueRef::Int32(v) => Value::Int32(v),
             ValueRef::Int64(v) => Value::Int64(v),
+            ValueRef::Int256(v) => Value::Int256(v),
             ValueRef::String(v) => Value::String(Arc::new(v.into())),
             ValueRef::Float32(v) => Value::Float32(v),
             ValueRef::Float64(v) => Value::Float64(v),
@@ -357,6 +362,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             Value::Int16(v) => ValueRef::Int16(*v),
             Value::Int32(v) => ValueRef::Int32(*v),
             Value::Int64(v) => ValueRef::Int64(*v),
+            Value::Int256(v) => ValueRef::Int256(*v),
             Value::String(v) => ValueRef::String(v),
             Value::Float32(v) => ValueRef::Float32(*v),
             Value::Float64(v) => ValueRef::Float64(*v),
@@ -376,7 +382,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
                     let value_ref: ValueRef<'a> = From::from(v);
                     ref_vec.push(value_ref)
                 }
-                ValueRef::Array(*t, Arc::new(ref_vec))
+                ValueRef::Array(t, Arc::new(ref_vec))
             }
             Value::Decimal(v) => ValueRef::Decimal(v.clone()),
             Value::Enum8(values, v) => ValueRef::Enum8(values.to_vec(), *v),
@@ -392,7 +398,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
                     let value_ref: ValueRef<'a> = From::from(v);
                     ref_map.insert(key_ref, value_ref);
                 }
-                ValueRef::Map(*k, *v, Arc::new(ref_map))
+                ValueRef::Map(k, v, Arc::new(ref_map))
             }
         }
     }
@@ -452,6 +458,7 @@ value_from! {
     i16: Int16,
     i32: Int32,
     i64: Int64,
+    I256: Int256,
 
     f32: Float32,
     f64: Float64

--- a/tests/clickhouse.rs
+++ b/tests/clickhouse.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 extern crate chrono;
 extern crate chrono_tz;
 extern crate clickhouse_rs;
@@ -1493,7 +1494,7 @@ async fn test_decimal() -> Result<(), Error> {
     let ox0: Option<Decimal> = block.get(0, "ox")?;
 
     assert_eq!(2, block.row_count());
-    assert_eq!(1.234, x.into());
+    assert_eq!(1.234, std::convert::Into::<f64>::into(x));
     assert_eq!(Some(1.23), ox.map(|v| v.into()));
     assert_eq!(None, ox0);
 
@@ -1986,7 +1987,7 @@ async fn test_iter_map() -> Result<(), Error> {
         ])),
         opt_map: Value::Map(
             SqlType::from(Value::UInt8(3).clone()).into(),
-            SqlType::from(Value::from(Some(4_u8)).clone()).into(),
+            SqlType::from(Value::from(Some(4_u8))).into(),
             Arc::new(HashMap::from([
                 (
                     Value::UInt8(3),


### PR DESCRIPTION
Please, add support for `I256` and possibly for `U256` also. I implemented this branch `ethnum::I256` and it works successfully with `SELECT` queries, but maybe I missed something for change database table methods. Also, I added here `ethabi::ethereum_types` cause on my project I used `FixedString(42)` for an Ethereum Address type, and `Uint256` works weirdly on CH, so I decide to use & impl that type to your crate.