### PR TITLE
[u256/i256] add support for u256/i256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ combine = "^4.6"
 percent-encoding = "^2.3"
 either = "^1.6"
 cfg-if = "1.0.0"
+ethnum = "^1.5.0"
 
 [dependencies.futures-util]
 version = "^0.3"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ clickhouse-rs = "*"
 * Decimal(P, S)
 * Float32, Float64
 * String, FixedString(N)
-* UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int32, Int64, Int128
+* UInt8, UInt16, UInt32, UInt64, UInt128, UInt256, Int8, Int16, Int32, Int64, Int128, UInt256
 * Nullable(T)
 * Array(UInt/Int/Float/String/Date/DateTime)
 * SimpleAggregateFunction(F, T)

--- a/src/types/block/mod.rs
+++ b/src/types/block/mod.rs
@@ -10,6 +10,7 @@ use std::{
 use byteorder::{LittleEndian, WriteBytesExt};
 use chrono_tz::Tz;
 use clickhouse_rs_cityhash_sys::city_hash_128;
+use ethnum::{i256, u256};
 use lz4::liblz4::{LZ4_compressBound, LZ4_compress_default};
 
 use crate::{
@@ -64,12 +65,14 @@ sliceable! {
     u32: UInt32,
     u64: UInt64,
     u128: UInt128,
+    u256: UInt256,
 
     i8: Int8,
     i16: Int16,
     i32: Int32,
     i64: Int64,
-    i128: Int128
+    i128: Int128,
+    i256: Int256
 }
 
 /// Represents Clickhouse Block

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -1,4 +1,5 @@
 use chrono_tz::Tz;
+use ethnum::{i256, u256};
 
 use combine::{
     any, choice,
@@ -67,11 +68,13 @@ impl dyn ColumnData {
             "UInt32" => W::wrap(VectorColumnData::<u32>::load(reader, size)?),
             "UInt64" => W::wrap(VectorColumnData::<u64>::load(reader, size)?),
             "UInt128" => W::wrap(VectorColumnData::<u128>::load(reader, size)?),
+            "UInt256" => W::wrap(VectorColumnData::<u256>::load(reader, size)?),
             "Int8" | "TinyInt" => W::wrap(VectorColumnData::<i8>::load(reader, size)?),
             "Int16" | "SmallInt" => W::wrap(VectorColumnData::<i16>::load(reader, size)?),
             "Int32" | "Int" | "Integer" => W::wrap(VectorColumnData::<i32>::load(reader, size)?),
             "Int64" | "BigInt" => W::wrap(VectorColumnData::<i64>::load(reader, size)?),
             "Int128" => W::wrap(VectorColumnData::<i128>::load(reader, size)?),
+            "Int256" => W::wrap(VectorColumnData::<i256>::load(reader, size)?),
             "Float32" | "Float" => W::wrap(VectorColumnData::<f32>::load(reader, size)?),
             "Float64" | "Double" => W::wrap(VectorColumnData::<f64>::load(reader, size)?),
             "String" | "Char" | "Varchar" | "Text" | "TinyText" | "MediumText" | "LongText" | "Blob" | "TinyBlob" | "MediumBlob" | "LongBlob" => W::wrap(StringColumnData::load(reader, size)?),
@@ -124,11 +127,13 @@ impl dyn ColumnData {
             SqlType::UInt32 => W::wrap(VectorColumnData::<u32>::with_capacity(capacity)),
             SqlType::UInt64 => W::wrap(VectorColumnData::<u64>::with_capacity(capacity)),
             SqlType::UInt128 => W::wrap(VectorColumnData::<u128>::with_capacity(capacity)),
+            SqlType::UInt256 => W::wrap(VectorColumnData::<u256>::with_capacity(capacity)),
             SqlType::Int8 => W::wrap(VectorColumnData::<i8>::with_capacity(capacity)),
             SqlType::Int16 => W::wrap(VectorColumnData::<i16>::with_capacity(capacity)),
             SqlType::Int32 => W::wrap(VectorColumnData::<i32>::with_capacity(capacity)),
             SqlType::Int64 => W::wrap(VectorColumnData::<i64>::with_capacity(capacity)),
             SqlType::Int128 => W::wrap(VectorColumnData::<i128>::with_capacity(capacity)),
+            SqlType::Int256 => W::wrap(VectorColumnData::<i256>::with_capacity(capacity)),
             SqlType::String => W::wrap(StringColumnData::with_capacity(capacity)),
             SqlType::FixedString(len) => {
                 W::wrap(FixedStringColumnData::with_capacity(capacity, len))

--- a/src/types/column/iter/mod.rs
+++ b/src/types/column/iter/mod.rs
@@ -2,6 +2,7 @@
 
 use chrono::prelude::*;
 use chrono_tz::Tz;
+use ethnum::{i256, u256};
 use std::{
     collections::HashMap,
     hash::Hash,
@@ -78,7 +79,10 @@ simple_num_iterable! {
     f64: Float64,
 
     i128: Int128,
-    u128: UInt128
+    u128: UInt128,
+
+    i256: Int256,
+    u256: UInt256
 }
 
 macro_rules! iterator {

--- a/src/types/column/numeric.rs
+++ b/src/types/column/numeric.rs
@@ -205,12 +205,14 @@ where
             Value::UInt32(x) => ValueRef::UInt32(x),
             Value::UInt64(x) => ValueRef::UInt64(x),
             Value::UInt128(x) => ValueRef::UInt128(x),
+            Value::UInt256(x) => ValueRef::UInt256(x),
 
             Value::Int8(x) => ValueRef::Int8(x),
             Value::Int16(x) => ValueRef::Int16(x),
             Value::Int32(x) => ValueRef::Int32(x),
             Value::Int64(x) => ValueRef::Int64(x),
             Value::Int128(x) => ValueRef::Int128(x),
+            Value::Int256(x) => ValueRef::Int256(x),
 
             Value::Float32(x) => ValueRef::Float32(x),
             Value::Float64(x) => ValueRef::Float64(x),

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -1,6 +1,7 @@
 use chrono::{prelude::*, Duration};
 use chrono_tz::Tz;
 use either::Either;
+use ethnum::{i256, u256};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -262,11 +263,13 @@ from_sql_vec_impl! {
     i32: Int32,
     i64: Int64,
     i128: Int128,
+    i256: Int256,
 
     u16: UInt16,
     u32: UInt32,
     u64: UInt64,
     u128: UInt128,
+    u256: UInt256,
 
     f32: Float32,
     f64: Float64
@@ -343,12 +346,14 @@ from_sql_impl! {
     u32: UInt32,
     u64: UInt64,
     u128: UInt128,
+    u256: UInt256,
 
     i8: Int8,
     i16: Int16,
     i32: Int32,
     i64: Int64,
     i128: Int128,
+    i256: Int256,
 
     f32: Float32,
     f64: Float64

--- a/src/types/marshal.rs
+++ b/src/types/marshal.rs
@@ -1,3 +1,5 @@
+use ethnum::{i256, u256};
+
 pub trait Marshal {
     fn marshal(&self, scratch: &mut [u8]);
 }
@@ -62,6 +64,13 @@ impl Marshal for u128 {
     }
 }
 
+impl Marshal for u256 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        self.low().marshal(&mut scratch[0..]);
+        self.high().marshal(&mut scratch[16..]);
+    }
+}
+
 impl Marshal for i8 {
     fn marshal(&self, scratch: &mut [u8]) {
         scratch[0] = *self as u8;
@@ -122,6 +131,13 @@ impl Marshal for i128 {
     }
 }
 
+impl Marshal for i256 {
+    fn marshal(&self, scratch: &mut [u8]) {
+        self.low().marshal(&mut scratch[0..]);
+        self.high().marshal(&mut scratch[16..]);
+    }
+}
+
 impl Marshal for f32 {
     fn marshal(&self, scratch: &mut [u8]) {
         let bits = self.to_bits();
@@ -157,6 +173,7 @@ mod test {
     use std::fmt;
 
     use crate::types::{Marshal, StatBuffer, Unmarshal};
+    use ethnum::{i256, u256};
     use rand::distributions::{Distribution, Standard};
     use rand::random;
 
@@ -202,6 +219,21 @@ mod test {
     }
 
     #[test]
+    fn test_u256() {
+        for _ in 0..100 {
+            let mut buffer = u256::buffer();
+            let v1 = random::<u128>();
+            let v2 = random::<u128>();
+            let v = u256::from_words(v1, v2);
+
+            v.marshal(buffer.as_mut());
+            let u = u256::unmarshal(buffer.as_ref());
+
+            assert_eq!(v, u);
+        }
+    }
+
+    #[test]
     fn test_i8() {
         test_some::<i8>()
     }
@@ -224,6 +256,21 @@ mod test {
     #[test]
     fn test_i128() {
         test_some::<i128>()
+    }
+
+    #[test]
+    fn test_i256() {
+        for _ in 0..100 {
+            let mut buffer = i256::buffer();
+            let v1 = random::<i128>();
+            let v2 = random::<i128>();
+            let v = i256::from_words(v1, v2);
+
+            v.marshal(buffer.as_mut());
+            let u = i256::unmarshal(buffer.as_ref());
+
+            assert_eq!(v, u);
+        }
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, collections::HashMap, fmt, mem, pin::Pin, str::FromStr, s
 
 use chrono::prelude::*;
 use chrono_tz::Tz;
+use ethnum::{i256, u256};
 use hostname::get;
 
 use lazy_static::lazy_static;
@@ -207,11 +208,13 @@ has_sql_type! {
     u32: SqlType::UInt32,
     u64: SqlType::UInt64,
     u128: SqlType::UInt128,
+    u256: SqlType::UInt256,
     i8: SqlType::Int8,
     i16: SqlType::Int16,
     i32: SqlType::Int32,
     i64: SqlType::Int64,
     i128: SqlType::Int128,
+    i256: SqlType::Int256,
     &str: SqlType::String,
     String: SqlType::String,
     f32: SqlType::Float32,
@@ -314,11 +317,13 @@ pub enum SqlType {
     UInt32,
     UInt64,
     UInt128,
+    UInt256,
     Int8,
     Int16,
     Int32,
     Int64,
     Int128,
+    Int256,
     String,
     FixedString(usize),
     Float32,
@@ -382,11 +387,13 @@ impl SqlType {
             SqlType::UInt32 => "UInt32".into(),
             SqlType::UInt64 => "UInt64".into(),
             SqlType::UInt128 => "UInt128".into(),
+            SqlType::UInt256 => "UInt256".into(),
             SqlType::Int8 => "Int8".into(),
             SqlType::Int16 => "Int16".into(),
             SqlType::Int32 => "Int32".into(),
             SqlType::Int64 => "Int64".into(),
             SqlType::Int128 => "Int128".into(),
+            SqlType::Int256 => "Int256".into(),
             SqlType::String => "String".into(),
             SqlType::FixedString(str_len) => format!("FixedString({str_len})").into(),
             SqlType::Float32 => "Float32".into(),

--- a/src/types/stat_buffer.rs
+++ b/src/types/stat_buffer.rs
@@ -1,4 +1,5 @@
 use crate::types::SqlType;
+use ethnum::{i256, u256};
 
 pub trait StatBuffer {
     type Buffer: AsMut<[u8]> + AsRef<[u8]> + Copy + Sync;
@@ -66,6 +67,18 @@ impl StatBuffer for u128 {
     }
 }
 
+impl StatBuffer for u256 {
+    type Buffer = [u8; 32];
+
+    fn buffer() -> Self::Buffer {
+        [0; 32]
+    }
+
+    fn sql_type() -> SqlType {
+        SqlType::UInt256
+    }
+}
+
 impl StatBuffer for i8 {
     type Buffer = [u8; 1];
 
@@ -123,6 +136,18 @@ impl StatBuffer for i128 {
 
     fn sql_type() -> SqlType {
         SqlType::Int128
+    }
+}
+
+impl StatBuffer for i256 {
+    type Buffer = [u8; 32];
+
+    fn buffer() -> Self::Buffer {
+        [0; 32]
+    }
+
+    fn sql_type() -> SqlType {
+        SqlType::Int256
     }
 }
 

--- a/src/types/unmarshal.rs
+++ b/src/types/unmarshal.rs
@@ -1,3 +1,5 @@
+use ethnum::{i256, u256};
+
 pub trait Unmarshal<T: Copy> {
     fn unmarshal(scratch: &[u8]) -> T;
 }
@@ -57,6 +59,15 @@ impl Unmarshal<u128> for u128 {
     }
 }
 
+impl Unmarshal<u256> for u256 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        Self::from_words(
+            u128::unmarshal(&scratch[16..]),
+            u128::unmarshal(&scratch[0..]),
+        )
+    }
+}
+
 impl Unmarshal<i8> for i8 {
     fn unmarshal(scratch: &[u8]) -> Self {
         scratch[0] as Self
@@ -109,6 +120,15 @@ impl Unmarshal<i128> for i128 {
             | Self::from(scratch[13]) << 104
             | Self::from(scratch[14]) << 112
             | Self::from(scratch[15]) << 120
+    }
+}
+
+impl Unmarshal<i256> for i256 {
+    fn unmarshal(scratch: &[u8]) -> Self {
+        Self::from_words(
+            i128::unmarshal(&scratch[16..]),
+            i128::unmarshal(&scratch[0..]),
+        )
     }
 }
 

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -9,6 +9,7 @@ use std::{
 use chrono::{prelude::*, Duration};
 use chrono_tz::Tz;
 use either::Either;
+use ethnum::{i256, u256};
 use uuid::Uuid;
 
 use crate::{
@@ -29,11 +30,13 @@ pub enum ValueRef<'a> {
     UInt32(u32),
     UInt64(u64),
     UInt128(u128),
+    UInt256(u256),
     Int8(i8),
     Int16(i16),
     Int32(i32),
     Int64(i64),
     Int128(i128),
+    Int256(i256),
     String(&'a [u8]),
     Float32(f32),
     Float64(f64),
@@ -64,11 +67,13 @@ impl<'a> Hash for ValueRef<'a> {
             Self::Int32(i) => i.hash(state),
             Self::Int64(i) => i.hash(state),
             Self::Int128(i) => i.hash(state),
+            Self::Int256(i) => i.hash(state),
             Self::UInt8(i) => i.hash(state),
             Self::UInt16(i) => i.hash(state),
             Self::UInt32(i) => i.hash(state),
             Self::UInt64(i) => i.hash(state),
             Self::UInt128(i) => i.hash(state),
+            Self::UInt256(i) => i.hash(state),
             _ => unimplemented!(),
         }
     }
@@ -84,11 +89,13 @@ impl<'a> PartialEq for ValueRef<'a> {
             (ValueRef::UInt32(a), ValueRef::UInt32(b)) => *a == *b,
             (ValueRef::UInt64(a), ValueRef::UInt64(b)) => *a == *b,
             (ValueRef::UInt128(a), ValueRef::UInt128(b)) => *a == *b,
+            (ValueRef::UInt256(a), ValueRef::UInt256(b)) => a.into_words() == b.into_words(),
             (ValueRef::Int8(a), ValueRef::Int8(b)) => *a == *b,
             (ValueRef::Int16(a), ValueRef::Int16(b)) => *a == *b,
             (ValueRef::Int32(a), ValueRef::Int32(b)) => *a == *b,
             (ValueRef::Int64(a), ValueRef::Int64(b)) => *a == *b,
             (ValueRef::Int128(a), ValueRef::Int128(b)) => *a == *b,
+            (ValueRef::Int256(a), ValueRef::Int256(b)) => a.into_words() == b.into_words(),
             (ValueRef::String(a), ValueRef::String(b)) => *a == *b,
             (ValueRef::Float32(a), ValueRef::Float32(b)) => *a == *b,
             (ValueRef::Float64(a), ValueRef::Float64(b)) => *a == *b,
@@ -132,11 +139,13 @@ impl<'a> fmt::Display for ValueRef<'a> {
             ValueRef::UInt32(v) => fmt::Display::fmt(v, f),
             ValueRef::UInt64(v) => fmt::Display::fmt(v, f),
             ValueRef::UInt128(v) => fmt::Display::fmt(v, f),
+            ValueRef::UInt256(v) => fmt::Display::fmt(v, f),
             ValueRef::Int8(v) => fmt::Display::fmt(v, f),
             ValueRef::Int16(v) => fmt::Display::fmt(v, f),
             ValueRef::Int32(v) => fmt::Display::fmt(v, f),
             ValueRef::Int64(v) => fmt::Display::fmt(v, f),
             ValueRef::Int128(v) => fmt::Display::fmt(v, f),
+            ValueRef::Int256(v) => fmt::Display::fmt(v, f),
             ValueRef::String(v) => match str::from_utf8(v) {
                 Ok(s) => fmt::Display::fmt(s, f),
                 Err(_) => write!(f, "{:?}", *v),
@@ -211,11 +220,13 @@ impl<'a> From<ValueRef<'a>> for SqlType {
             ValueRef::UInt32(_) => SqlType::UInt32,
             ValueRef::UInt64(_) => SqlType::UInt64,
             ValueRef::UInt128(_) => SqlType::UInt128,
+            ValueRef::UInt256(_) => SqlType::UInt256,
             ValueRef::Int8(_) => SqlType::Int8,
             ValueRef::Int16(_) => SqlType::Int16,
             ValueRef::Int32(_) => SqlType::Int32,
             ValueRef::Int64(_) => SqlType::Int64,
             ValueRef::Int128(_) => SqlType::Int128,
+            ValueRef::Int256(_) => SqlType::Int256,
             ValueRef::String(_) => SqlType::String,
             ValueRef::Float32(_) => SqlType::Float32,
             ValueRef::Float64(_) => SqlType::Float64,
@@ -279,11 +290,13 @@ impl<'a> From<ValueRef<'a>> for Value {
             ValueRef::UInt32(v) => Value::UInt32(v),
             ValueRef::UInt64(v) => Value::UInt64(v),
             ValueRef::UInt128(v) => Value::UInt128(v),
+            ValueRef::UInt256(v) => Value::UInt256(v),
             ValueRef::Int8(v) => Value::Int8(v),
             ValueRef::Int16(v) => Value::Int16(v),
             ValueRef::Int32(v) => Value::Int32(v),
             ValueRef::Int64(v) => Value::Int64(v),
             ValueRef::Int128(v) => Value::Int128(v),
+            ValueRef::Int256(v) => Value::Int256(v),
             ValueRef::String(v) => Value::String(Arc::new(v.into())),
             ValueRef::Float32(v) => Value::Float32(v),
             ValueRef::Float64(v) => Value::Float64(v),
@@ -356,12 +369,14 @@ from_number! {
     u32: UInt32,
     u64: UInt64,
     u128: UInt128,
+    u256: UInt256,
 
     i8: Int8,
     i16: Int16,
     i32: Int32,
     i64: Int64,
     i128: Int128,
+    i256: Int256,
 
     f32: Float32,
     f64: Float64
@@ -376,11 +391,13 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             Value::UInt32(v) => ValueRef::UInt32(*v),
             Value::UInt64(v) => ValueRef::UInt64(*v),
             Value::UInt128(v) => ValueRef::UInt128(*v),
+            Value::UInt256(v) => ValueRef::UInt256(*v),
             Value::Int8(v) => ValueRef::Int8(*v),
             Value::Int16(v) => ValueRef::Int16(*v),
             Value::Int32(v) => ValueRef::Int32(*v),
             Value::Int64(v) => ValueRef::Int64(*v),
             Value::Int128(v) => ValueRef::Int128(*v),
+            Value::Int256(v) => ValueRef::Int256(*v),
             Value::String(v) => ValueRef::String(v),
             Value::Float32(v) => ValueRef::Float32(*v),
             Value::Float64(v) => ValueRef::Float64(*v),
@@ -495,12 +512,14 @@ value_from! {
     u32: UInt32,
     u64: UInt64,
     u128: UInt128,
+    u256: UInt256,
 
     i8: Int8,
     i16: Int16,
     i32: Int32,
     i64: Int64,
     i128: Int128,
+    i256: Int256,
 
     f32: Float32,
     f64: Float64
@@ -525,12 +544,20 @@ mod test {
         assert_eq!("42".to_string(), format!("{}", ValueRef::UInt32(42)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::UInt64(42)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::UInt128(42)));
+        assert_eq!(
+            "42".to_string(),
+            format!("{}", ValueRef::UInt256(u256::new(42)))
+        );
 
         assert_eq!("42".to_string(), format!("{}", ValueRef::Int8(42)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::Int16(42)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::Int32(42)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::Int64(42)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::Int128(42)));
+        assert_eq!(
+            "42".to_string(),
+            format!("{}", ValueRef::Int256(i256::new(42)))
+        );
 
         assert_eq!("42".to_string(), format!("{}", ValueRef::Float32(42.0)));
         assert_eq!("42".to_string(), format!("{}", ValueRef::Float64(42.0)));
@@ -591,7 +618,7 @@ mod test {
     #[test]
     fn test_size_of() {
         use std::mem;
-        assert_eq!(32, mem::size_of::<[ValueRef<'_>; 1]>());
+        assert_eq!(40, mem::size_of::<[ValueRef<'_>; 1]>());
     }
 
     #[test]
@@ -601,12 +628,20 @@ mod test {
         assert_eq!(Value::from(ValueRef::UInt32(42)), Value::UInt32(42));
         assert_eq!(Value::from(ValueRef::UInt64(42)), Value::UInt64(42));
         assert_eq!(Value::from(ValueRef::UInt128(42)), Value::UInt128(42));
+        assert_eq!(
+            Value::from(ValueRef::UInt256(u256::new(42))),
+            Value::UInt256(u256::new(42))
+        );
 
         assert_eq!(Value::from(ValueRef::Int8(42)), Value::Int8(42));
         assert_eq!(Value::from(ValueRef::Int16(42)), Value::Int16(42));
         assert_eq!(Value::from(ValueRef::Int32(42)), Value::Int32(42));
         assert_eq!(Value::from(ValueRef::Int64(42)), Value::Int64(42));
         assert_eq!(Value::from(ValueRef::Int128(42)), Value::Int128(42));
+        assert_eq!(
+            Value::from(ValueRef::Int256(i256::new(42))),
+            Value::Int256(i256::new(42))
+        );
 
         assert_eq!(Value::from(ValueRef::Float32(42.0)), Value::Float32(42.0));
         assert_eq!(Value::from(ValueRef::Float64(42.0)), Value::Float64(42.0));
@@ -655,12 +690,20 @@ mod test {
         assert_eq!(SqlType::from(ValueRef::UInt32(42)), SqlType::UInt32);
         assert_eq!(SqlType::from(ValueRef::UInt64(42)), SqlType::UInt64);
         assert_eq!(SqlType::from(ValueRef::UInt128(42)), SqlType::UInt128);
+        assert_eq!(
+            SqlType::from(ValueRef::UInt256(u256::new(42))),
+            SqlType::UInt256
+        );
 
         assert_eq!(SqlType::from(ValueRef::Int8(42)), SqlType::Int8);
         assert_eq!(SqlType::from(ValueRef::Int16(42)), SqlType::Int16);
         assert_eq!(SqlType::from(ValueRef::Int32(42)), SqlType::Int32);
         assert_eq!(SqlType::from(ValueRef::Int64(42)), SqlType::Int64);
         assert_eq!(SqlType::from(ValueRef::Int128(42)), SqlType::Int128);
+        assert_eq!(
+            SqlType::from(ValueRef::Int256(i256::new(42))),
+            SqlType::Int256
+        );
 
         assert_eq!(SqlType::from(ValueRef::Float32(42.0)), SqlType::Float32);
         assert_eq!(SqlType::from(ValueRef::Float64(42.0)), SqlType::Float64);


### PR DESCRIPTION
Hi! I've seen existed [issue](https://github.com/suharev7/clickhouse-rs/issues/196)

Took implementation https://crates.io/crates/ethnum and this [commit](https://github.com/suharev7/clickhouse-rs/commit/45420fb222107fc6d7244b35aa9d5c773deeeaa8) as a source of inspiration
Standard: Distribution trait is not implemented for 256-bit integer so marshal tests look a bit ugly