### PR TITLE
add support for Decimal128(S)

### DIFF
--- a/src/types/block/builder.rs
+++ b/src/types/block/builder.rs
@@ -206,6 +206,6 @@ mod test {
             block.columns[14].sql_type(),
             SqlType::DateTime(DateTimeType::Chrono)
         );
-        assert_eq!(block.columns[15].sql_type(), SqlType::Decimal(18, 4));
+        assert_eq!(block.columns[15].sql_type(), SqlType::Decimal(38, 4));
     }
 }

--- a/src/types/column/factory.rs
+++ b/src/types/column/factory.rs
@@ -182,6 +182,7 @@ impl dyn ColumnData {
                 let inner_type = match nobits {
                     NoBits::N32 => SqlType::Int32,
                     NoBits::N64 => SqlType::Int64,
+                    NoBits::N128 => SqlType::Int128,
                 };
 
                 W::wrap(DecimalColumnData {
@@ -382,6 +383,7 @@ fn parse_decimal(source: &str) -> Option<(u8, u8, NoBits)> {
             let precision = match bits {
                 NoBits::N32 => 9,
                 NoBits::N64 => 18,
+                NoBits::N128 => 38,
             };
             Some((precision, scale, bits))
         }
@@ -554,7 +556,7 @@ mod test {
     fn test_parse_decimal() {
         assert_eq!(parse_decimal("Decimal(9, 4)"), Some((9, 4, NoBits::N32)));
         assert_eq!(parse_decimal("Decimal(10, 4)"), Some((10, 4, NoBits::N64)));
-        assert_eq!(parse_decimal("Decimal(20, 4)"), None);
+        assert_eq!(parse_decimal("Decimal(20, 4)"), Some((20, 4, NoBits::N128)));
         assert_eq!(parse_decimal("Decimal(2000, 4)"), None);
         assert_eq!(parse_decimal("Decimal(3, 4)"), None);
         assert_eq!(parse_decimal("Decimal(20, -4)"), None);

--- a/src/types/column/iter/mod.rs
+++ b/src/types/column/iter/mod.rs
@@ -309,7 +309,7 @@ impl<'a> DecimalIterator<'a> {
     unsafe fn next_unchecked_<T>(&mut self) -> Decimal
     where
         T: Copy + Sized,
-        i64: From<T>,
+        i128: From<T>,
     {
         let current_value = *(self.ptr as *const T);
         self.ptr = (self.ptr as *const T).offset(1) as *const u8;
@@ -327,6 +327,7 @@ impl<'a> DecimalIterator<'a> {
         match self.nobits {
             NoBits::N32 => self.next_unchecked_::<i32>(),
             NoBits::N64 => self.next_unchecked_::<i64>(),
+            NoBits::N128 => self.next_unchecked_::<i128>(),
         }
     }
 
@@ -336,6 +337,7 @@ impl<'a> DecimalIterator<'a> {
             match self.nobits {
                 NoBits::N32 => self.ptr = (self.ptr as *const i32).add(n) as *const u8,
                 NoBits::N64 => self.ptr = (self.ptr as *const i64).add(n) as *const u8,
+                NoBits::N128 => self.ptr = (self.ptr as *const i128).add(n) as *const u8,
             }
         }
     }
@@ -347,6 +349,7 @@ impl<'a> ExactSizeIterator for DecimalIterator<'a> {
         let size = match self.nobits {
             NoBits::N32 => mem::size_of::<i32>(),
             NoBits::N64 => mem::size_of::<i64>(),
+            NoBits::N128 => mem::size_of::<i128>(),
         };
         (self.end as usize - self.ptr as usize) / size
     }
@@ -983,6 +986,7 @@ impl<'a> Iterable<'a, Simple> for Decimal {
             match nobits {
                 NoBits::N32 => (ptr as *const u32).add(size) as *const u8,
                 NoBits::N64 => (ptr as *const u64).add(size) as *const u8,
+                NoBits::N128 => (ptr as *const u128).add(size) as *const u8,
             }
         };
 

--- a/src/types/value_ref.rs
+++ b/src/types/value_ref.rs
@@ -675,7 +675,7 @@ mod test {
 
         assert_eq!(
             SqlType::from(ValueRef::Decimal(Decimal::of(2.0_f64, 4))),
-            SqlType::Decimal(18, 4)
+            SqlType::Decimal(38, 4)
         );
 
         assert_eq!(

--- a/tests/clickhouse.rs
+++ b/tests/clickhouse.rs
@@ -1712,14 +1712,16 @@ async fn test_decimal() -> Result<(), Error> {
     let ddl = "
         CREATE TABLE clickhouse_decimal (
             x  Decimal(8, 3),
-            ox Nullable(Decimal(10, 2))
+            ox Nullable(Decimal(10, 2)),
+            xx Decimal(30, 4)
         ) Engine=Memory";
 
-    let query = "SELECT x, ox FROM clickhouse_decimal";
+    let query = "SELECT x, ox, xx FROM clickhouse_decimal";
 
     let block = Block::new()
         .column("x", vec![Decimal::of(1.234, 3), Decimal::of(5, 3)])
-        .column("ox", vec![None, Some(Decimal::of(1.23, 2))]);
+        .column("ox", vec![None, Some(Decimal::of(1.23, 2))])
+        .column("xx", vec![Decimal::of(1.23456, 4), Decimal::of(5, 4)]);
 
     let pool = Pool::new(database_url());
 
@@ -1732,11 +1734,13 @@ async fn test_decimal() -> Result<(), Error> {
     let x: Decimal = block.get(0, "x")?;
     let ox: Option<Decimal> = block.get(1, "ox")?;
     let ox0: Option<Decimal> = block.get(0, "ox")?;
+    let xx: Decimal = block.get(0, "xx")?;
 
     assert_eq!(2, block.row_count());
     assert_eq!(1.234, x.into());
     assert_eq!(Some(1.23), ox.map(|v| v.into()));
     assert_eq!(None, ox0);
+    assert_eq!(1.2345, xx.into());
 
     Ok(())
 }


### PR DESCRIPTION
suharev7/clickhouse-rs#206

Rust doesn't have a standard library for u258/i256, so this pr only adds support for Decimal128