### PR TITLE
Fix possible panic in case broken protocol

### DIFF
--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -119,7 +119,7 @@ impl ClickhouseTransport {
             }
         }
 
-        let mut transport = h.unwrap();
+        let mut transport = h.ok_or(Error::Driver(DriverError::UnexpectedPacket))?;
         transport.inconsistent = false;
         Ok(transport)
     }


### PR DESCRIPTION
stacktrace:

    thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/io/transport.rs:122:31

       8: core::option::Option<T>::unwrap
                 at /rustc/0ab38e95bb1cbf0bd038d359bdecbfa501f003a7/library/core/src/option.rs:935:21
       9: clickhouse_rs::io::transport::ClickhouseTransport::clear::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/io/transport.rs:122:29
      10: clickhouse_rs::ClientHandle::ping::{{closure}}::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/lib.rs:340:59
      11: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll
                 at /home/azat/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/time/timeout.rs:202:33
      12: clickhouse_rs::with_timeout::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/lib.rs:641:43
      13: clickhouse_rs::ClientHandle::ping::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/lib.rs:365:10
      14: clickhouse_rs::retry_guard::check::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/retry_guard.rs:57:14
      15: clickhouse_rs::retry_guard::retry_guard::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/retry_guard.rs:21:33
      16: clickhouse_rs::ClientHandle::check_connection::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/lib.rs:586:78
      17: clickhouse_rs::ClientHandle::wrap_stream::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/lib.rs:555:89
      ...
      26: clickhouse_rs::with_timeout::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/lib.rs:641:43
      27: clickhouse_rs::types::query_result::QueryResult::fetch_all::{{closure}}
                 at /home/azat/.cargo/git/checkouts/clickhouse-rs-37da3cb97e01332d/afd8ce5/src/types/query_result/mod.rs:47:10