### PR TITLE
feat: Add QueryResultOwned type for lifetime-independent streaming

### DIFF
--- a/src/types/column/datetime64.rs
+++ b/src/types/column/datetime64.rs
@@ -156,7 +156,7 @@ pub(crate) fn to_native_datetime_opt(value: i64, precision: u32) -> Option<Naive
     let sec = nano / 1_000_000_000;
     let nsec = nano - sec * 1_000_000_000;
 
-    NaiveDateTime::from_timestamp_opt(sec, nsec as u32)
+    DateTime::<Utc>::from_timestamp(sec, nsec as u32).map(|d| d.naive_utc())
 }
 
 #[cfg(test)]

--- a/src/types/column/iter/mod.rs
+++ b/src/types/column/iter/mod.rs
@@ -307,9 +307,9 @@ impl FusedIterator for StringIterator<'_> {}
 impl<'a> DecimalIterator<'a> {
     #[inline(always)]
     unsafe fn next_unchecked_<T>(&mut self) -> Decimal
-    where
-        T: Copy + Sized,
-        i64: From<T>,
+        where
+            T: Copy + Sized,
+            i64: From<T>,
     {
         let current_value = *(self.ptr as *const T);
         self.ptr = (self.ptr as *const T).offset(1) as *const u8;
@@ -479,7 +479,7 @@ impl<'a> NativeDateTimeIterator<'a> {
         match &self.inner {
             DateTimeInnerIterator::DateTime32(ptr) => {
                 let current_value = *ptr.add(index_);
-                NaiveDateTime::from_timestamp_opt(i64::from(current_value), 0).unwrap()
+                DateTime::from_timestamp(i64::from(current_value), 0).unwrap().naive_utc()
             }
             DateTimeInnerIterator::DateTime64(ptr, precision) => {
                 let current_value = *ptr.add(index_);
@@ -664,8 +664,8 @@ impl<'a> Iterator for DateTimeIterator<'a> {
 }
 
 impl<'a, I> ExactSizeIterator for NullableIterator<'a, I>
-where
-    I: Iterator,
+    where
+        I: Iterator,
 {
     #[inline(always)]
     fn len(&self) -> usize {
@@ -675,8 +675,8 @@ where
 }
 
 impl<'a, I> Iterator for NullableIterator<'a, I>
-where
-    I: Iterator,
+    where
+        I: Iterator,
 {
     type Item = Option<I::Item>;
 
@@ -758,8 +758,8 @@ impl<'a, I: Iterator> Iterator for ArrayIterator<'a, I> {
 impl<'a, I: Iterator> FusedIterator for ArrayIterator<'a, I> {}
 
 impl<'a, K: Iterator, V: Iterator> ExactSizeIterator for MapIterator<'a, K, V>
-where
-    K::Item: Eq + Hash,
+    where
+        K::Item: Eq + Hash,
 {
     #[inline(always)]
     fn len(&self) -> usize {
@@ -768,8 +768,8 @@ where
 }
 
 impl<'a, K: Iterator, V: Iterator> Iterator for MapIterator<'a, K, V>
-where
-    K::Item: Eq + Hash,
+    where
+        K::Item: Eq + Hash,
 {
     type Item = HashMap<K::Item, V::Item>;
 
@@ -935,7 +935,7 @@ impl<'a> Iterable<'a, Simple> for &[u8] {
                 return Err(Error::FromSql(FromSqlError::InvalidType {
                     src: column.sql_type().to_string(),
                     dst: SqlType::String.to_string(),
-                }))
+                }));
             }
         };
 
@@ -1196,8 +1196,8 @@ fn date_iter(column: &Column<Simple>, props: u32) -> Result<DateTimeInternals> {
 }
 
 impl<'a, T> Iterable<'a, Simple> for Option<T>
-where
-    T: Iterable<'a, Simple>,
+    where
+        T: Iterable<'a, Simple>,
 {
     type Iter = NullableIterator<'a, T::Iter>;
 
@@ -1238,8 +1238,8 @@ where
 }
 
 impl<'a, T> Iterable<'a, Simple> for Vec<T>
-where
-    T: Iterable<'a, Simple>,
+    where
+        T: Iterable<'a, Simple>,
 {
     type Iter = ArrayIterator<'a, T::Iter>;
 
@@ -1279,10 +1279,10 @@ where
 }
 
 impl<'a, K, V> Iterable<'a, Simple> for HashMap<K, V>
-where
-    K: Iterable<'a, Simple>,
-    <<K as Iterable<'a, Simple>>::Iter as Iterator>::Item: Eq + Hash,
-    V: Iterable<'a, Simple>,
+    where
+        K: Iterable<'a, Simple>,
+        <<K as Iterable<'a, Simple>>::Iter as Iterator>::Item: Eq + Hash,
+        V: Iterable<'a, Simple>,
 {
     type Iter = MapIterator<'a, K::Iter, V::Iter>;
 
@@ -1328,8 +1328,8 @@ where
 }
 
 pub struct ComplexIterator<'a, T>
-where
-    T: Iterable<'a, Simple>,
+    where
+        T: Iterable<'a, Simple>,
 {
     column_type: SqlType,
 
@@ -1342,8 +1342,8 @@ where
 }
 
 impl<'a, T> Iterator for ComplexIterator<'a, T>
-where
-    T: Iterable<'a, Simple>,
+    where
+        T: Iterable<'a, Simple>,
 {
     type Item = <<T as Iterable<'a, Simple>>::Iter as Iterator>::Item;
 
@@ -1392,8 +1392,8 @@ where
 }
 
 impl<'a, T> Iterable<'a, Complex> for T
-where
-    T: Iterable<'a, Simple> + 'a,
+    where
+        T: Iterable<'a, Simple> + 'a,
 {
     type Iter = ComplexIterator<'a, T>;
 

--- a/src/types/from_sql.rs
+++ b/src/types/from_sql.rs
@@ -106,9 +106,9 @@ impl<'a> FromSql<'a> for String {
 }
 
 impl<'a, K, V> FromSql<'a> for HashMap<K, V>
-where
-    K: FromSql<'a> + Eq + PartialEq + Hash,
-    V: FromSql<'a>,
+    where
+        K: FromSql<'a> + Eq + PartialEq + Hash,
+        V: FromSql<'a>,
 {
     fn from_sql(value: ValueRef<'a>) -> FromSqlResult<Self> {
         if let ValueRef::Map(_k, _v, hm) = value {
@@ -274,8 +274,8 @@ from_sql_vec_impl! {
 }
 
 impl<'a, T> FromSql<'a> for Option<T>
-where
-    T: FromSql<'a>,
+    where
+        T: FromSql<'a>,
 {
     fn from_sql(value: ValueRef<'a>) -> FromSqlResult<Self> {
         match value {
@@ -301,7 +301,7 @@ impl<'a> FromSql<'a> for NaiveDate {
     fn from_sql(value: ValueRef<'a>) -> FromSqlResult<Self> {
         match value {
             ValueRef::Date(v) => NaiveDate::from_ymd_opt(1970, 1, 1)
-                .map(|unix_epoch| unix_epoch + Duration::days(v.into()))
+                .map(|unix_epoch| unix_epoch + Duration::try_days(v.into()).expect("TimeDelta::days out of bounds"))
                 .ok_or(Error::FromSql(FromSqlError::OutOfRange)),
             _ => {
                 let from = SqlType::from(value).to_string();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -46,6 +46,7 @@ mod cmd;
 mod date_converter;
 mod query;
 pub(crate) mod query_result;
+pub(crate) mod query_result_owned;
 
 mod decimal;
 mod enums;

--- a/src/types/query_result_owned/mod.rs
+++ b/src/types/query_result_owned/mod.rs
@@ -1,0 +1,125 @@
+use futures_util::{
+    future,
+    stream::{self, BoxStream, StreamExt},
+    TryStreamExt,
+};
+use log::info;
+use std::{marker::PhantomData, sync::Arc};
+
+use crate::{
+    errors::Result,
+    try_opt,
+    types::{
+        block::BlockRef, query_result_owned::stream_blocks::BlockStreamOwned, Block, Cmd, Complex, Query, Row,
+        Rows, Simple,
+    },
+    with_timeout, ClientHandle,
+};
+
+pub(crate) mod stream_blocks;
+
+/// Result of a query or statement execution.
+pub struct QueryResultOwned {
+    pub(crate) client: ClientHandle,
+    pub(crate) query: Query,
+}
+
+impl QueryResultOwned {
+    /// Fetch data from table. It returns a block that contains all rows.
+    pub async fn fetch_all(self) -> Result<Block<Complex>> {
+        let timeout = try_opt!(self.client.context.options.get()).query_timeout;
+
+        with_timeout(
+            async {
+                let blocks = self
+                    .stream_blocks_(false)
+                    .try_fold(Vec::new(), |mut blocks, block| {
+                        if !block.is_empty() {
+                            blocks.push(block);
+                        }
+                        future::ready(Ok(blocks))
+                    })
+                    .await?;
+                Ok(Block::concat(blocks.as_slice()))
+            },
+            timeout,
+        )
+            .await
+    }
+
+    /// Method that produces a stream of blocks containing rows
+    ///
+    /// example:
+    ///
+    /// ```rust
+    /// # use std::env;
+    /// # use clickhouse_rs::{Pool, errors::Result};
+    /// # use futures_util::{future, TryStreamExt};
+    /// #
+    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let ret: Result<()> = rt.block_on(async {
+    /// #
+    /// #     let database_url = env::var("DATABASE_URL")
+    /// #         .unwrap_or("tcp://localhost:9000?compression=lz4".into());
+    /// #
+    /// #     let sql_query = "SELECT number FROM system.numbers LIMIT 100000";
+    /// #     let pool = Pool::new(database_url);
+    /// #
+    ///       let mut c = pool.get_handle().await?;
+    ///       let mut result = c.query_owned(sql_query)
+    ///           .stream_blocks()
+    ///           .try_for_each(|block| {
+    ///               println!("{:?}\nblock counts: {} rows", block, block.row_count());
+    ///               future::ready(Ok(()))
+    ///           }).await?;
+    /// #     Ok(())
+    /// # });
+    /// # ret.unwrap()
+    /// ```
+    pub fn stream_blocks(self) -> BoxStream<'static, Result<Block>> {
+        self.stream_blocks_(true)
+    }
+
+    fn stream_blocks_(self, skip_first_block: bool) -> BoxStream<'static, Result<Block>> {
+        let query = self.query.clone();
+
+        self.client
+            .wrap_stream_owned::<_>(move |mut c: ClientHandle| {
+                info!("[send query] {}", query.get_sql());
+                c.pool.detach();
+
+                let context = c.context.clone();
+
+                let inner = c.get_inner()?.call(Cmd::SendQuery(query, context));
+
+                Ok(BlockStreamOwned::new(c, inner, skip_first_block))
+            })
+    }
+
+    /// Method that produces a stream of rows
+    pub fn stream(self) -> BoxStream<'static, Result<Row<'static, Simple>>> {
+        Box::pin(
+            self.stream_blocks()
+                .map(|block_ret| {
+                    let result: BoxStream<'static, Result<Row<'static, Simple>>> = match block_ret {
+                        Ok(block) => {
+                            let block = Arc::new(block);
+                            let block_ref = BlockRef::Owned(block);
+
+                            Box::pin(
+                                stream::iter(Rows {
+                                    row: 0,
+                                    block_ref,
+                                    kind: PhantomData,
+                                })
+                                    .map(|row| -> Result<Row<'static, Simple>> { Ok(row) }),
+                            )
+                        }
+                        Err(err) => Box::pin(stream::once(future::err(err))),
+                    };
+                    result
+                })
+                .flatten(),
+        )
+    }
+}

--- a/src/types/query_result_owned/stream_blocks.rs
+++ b/src/types/query_result_owned/stream_blocks.rs
@@ -1,0 +1,123 @@
+use std::{
+    borrow::Cow,
+    io::ErrorKind,
+    pin::Pin,
+    task::{self, Poll},
+};
+
+use futures_core::Stream;
+use futures_util::StreamExt;
+
+use crate::{
+    errors::{DriverError, Error, Result},
+    io::transport::PacketStream,
+    types::{Block, Packet},
+    ClientHandle,
+};
+
+pub(crate) struct BlockStreamOwned {
+    client: ClientHandle,
+    inner: PacketStream,
+    state: BlockStreamState,
+    block_index: usize,
+    skip_first_block: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum BlockStreamState {
+    /// Currently reading from block packet stream; some further packets may be pending
+    Reading,
+    /// Completely finished reading from block packet stream; connection is now idle
+    Finished,
+    /// There was an error reading packet; transport is broken
+    Error,
+}
+
+impl Drop for BlockStreamOwned {
+    fn drop(&mut self) {
+        match self.state {
+            BlockStreamState::Reading => {
+                if !self.client.pool.is_attached() {
+                    self.client.pool.attach();
+                }
+
+                if let Some(mut transport) = self.inner.take_transport() {
+                    transport.inconsistent = true;
+                    self.client.inner = Some(transport);
+                }
+            }
+            BlockStreamState::Finished => {}
+            BlockStreamState::Error => {
+                // drop broken transport; don't return it to pool to prevent pool poisoning
+            }
+        }
+    }
+}
+
+impl BlockStreamOwned {
+    pub(crate) fn new(
+        client: ClientHandle,
+        inner: PacketStream,
+        skip_first_block: bool,
+    ) -> BlockStreamOwned {
+        BlockStreamOwned {
+            client,
+            inner,
+            state: BlockStreamState::Reading,
+            block_index: 0,
+            skip_first_block,
+        }
+    }
+}
+
+impl Stream for BlockStreamOwned {
+    type Item = Result<Block>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.state {
+                BlockStreamState::Reading => {}
+                BlockStreamState::Finished => return Poll::Ready(None),
+                BlockStreamState::Error => {
+                    return Poll::Ready(Some(Err(Error::Other(Cow::Borrowed(
+                        "Attempt to read from broken transport",
+                    )))));
+                }
+            };
+
+            let packet = match self.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err.into()))),
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => {
+                    self.state = BlockStreamState::Error;
+                    return Poll::Ready(Some(Err(Error::Io(std::io::Error::from(
+                        ErrorKind::UnexpectedEof,
+                    )))));
+                }
+                Poll::Ready(Some(Ok(packet))) => packet,
+            };
+
+            match packet {
+                Packet::Eof(inner) => {
+                    self.client.inner = Some(inner);
+                    if !self.client.pool.is_attached() {
+                        self.client.pool.attach();
+                    }
+                    self.state = BlockStreamState::Finished;
+                }
+                Packet::ProfileInfo(_) | Packet::Progress(_) => {}
+                Packet::Exception(exception) => {
+                    self.state = BlockStreamState::Finished;
+                    return Poll::Ready(Some(Err(Error::Server(exception))));
+                }
+                Packet::Block(block) => {
+                    self.block_index += 1;
+                    if (self.block_index > 1 || !self.skip_first_block) && !block.is_empty() {
+                        return Poll::Ready(Some(Ok(block)));
+                    }
+                }
+                _ => return Poll::Ready(Some(Err(Error::Driver(DriverError::UnexpectedPacket)))),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented `QueryResultOwned` to solve lifetime issues encountered with streaming query results in asynchronous contexts. This type facilitates creating streams with `'static` lifetimes, enabling easier integration into async workflows and structures that require static lifetime guarantees.

**Key Changes:**

- Added `QueryResultOwned` for lifetime-independent query result streaming.
- Ensured compatibility with existing streaming functionalities.

**Background:**
Developing async applications with the existing query streaming mechanism led to challenges due to Rust's strict lifetime requirements. Specifically, returning streams from async functions or storing them for later use was cumbersome because of lifetime ties to the client or query string.

**Usage:**
```rust
let query_result_owned = client.query_owned("SELECT * FROM table");
let stream = query_result_owned.stream(); // Stream with `'static` lifetime
```
