### PR TITLE
Properly handle terminated connection by the server and fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         image: clickhouse/clickhouse-server
         ports:
           - 9000:9000
+        env:
+          CLICKHOUSE_SKIP_USER_SETUP: 1
     steps:
       - uses: actions/checkout@v3
       - name: Build
@@ -45,6 +47,7 @@ jobs:
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
+          -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
           --rm
           --detach
@@ -72,6 +75,7 @@ jobs:
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
+          -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
           --rm
           --detach

--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -287,6 +287,15 @@ impl Stream for ClickhouseTransport {
         }
 
         if *this.done {
+            // We still have may have something in buffer, since the client may read something
+            // first, and only after the server will close the connection, likely in case of
+            // exception, let's try to parse it here
+            if !this.rd.is_empty() {
+                if let Poll::Ready(ret) = this.try_parse_msg()? {
+                    return Poll::Ready(ret.map(Ok));
+                }
+            }
+
             return Poll::Ready(None);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl ClientHandle {
         }
 
         self.inner = h;
-        self.context.server_info = info.unwrap();
+        self.context.server_info = info.ok_or(Error::Other("Missing Hello/Exception packet".into()))?;
         Ok(())
     }
 

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -806,7 +806,7 @@ mod test {
     #[test]
     fn test_size_of() {
         use std::mem;
-        assert_eq!(56, mem::size_of::<[Value; 1]>());
+        assert_eq!(64, mem::size_of::<[Value; 1]>());
     }
 
     #[test]


### PR DESCRIPTION
Previously ClickhouseTransport::poll_next did not tries to process
packets if the server closed the connection, however there can be some
packet (likely Exception), that we need to pass to user.

Also this will avoid panic in case of missing Hello packet, i.e. in
case of credentials mismatch.