### PR TITLE
Add support for authentication via mTLS (authentication with TLS certificates)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - async-await
-      - next
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
 
   build-tls:
     strategy:
+      fail-fast: false
       matrix:
         feature:
           - tls-native-tls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,14 @@ jobs:
         feature:
           - tls-native-tls
           - tls-rustls
+        options:
+          - skip_verify=true
+          - certificate=$CH_SSL_CERTIFICATE
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
       # NOTE: sometimes for native-tls default connection_timeout (500ms) is not enough, interestingly that for rustls it is OK.
-      DATABASE_URL: "tcp://localhost:9440?compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&skip_verify=true&connection_timeout=5s"
+      DATABASE_URL: "tcp://localhost:9440?compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&${{ matrix.options }}&connection_timeout=5s"
     steps:
       - uses: actions/checkout@v3
       # NOTE:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,31 +41,19 @@ jobs:
           # for TLS we need skip_verify for self-signed certificate
           - tcp://localhost:9440?skip_verify=true
           # we don't need skip_verify when we pass CA cert
-          - tcp://localhost:9440?ca_certificate=/tmp/ca.pem
-        # mTLS
-        include:
-          - feature: tls-native-tls
-            database_url: tcp://tls@localhost:9440?ca_certificate=/tmp/ca.pem&tls_identity=/tmp/client.p12
-          - feature: tls-rustls
-            database_url: tcp://tls@localhost:9440?ca_certificate=/tmp/ca.pem&certificate_file=/tmp/client.crt&private_key_file=/tmp/client.key
+          - tcp://localhost:9440?ca_certificate=tls/ca.pem
+          # mTLS
+          - tcp://tls@localhost:9440?ca_certificate=tls/ca.pem&client_certificate=tls/client.crt&client_private_key=tls/client.key
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
       # NOTE: sometimes for native-tls default connection_timeout (500ms) is not enough, interestingly that for rustls it is OK.
       DATABASE_URL: ${{ matrix.database_url }}&compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&connection_timeout=5s
-      CH_SSL_CA_CERTIFICATE: /tmp/ca.pem
-      CH_SSL_CERTIFICATE: /tmp/server.crt
-      CH_SSL_PRIVATE_KEY: /tmp/server.key
-      CH_SSL_CLIENT_PRIVATE_KEY: /tmp/client.key
-      CH_SSL_CLIENT_CERTIFICATE: /tmp/client.crt
-      CH_SSL_CLIENT_P12: /tmp/client.p12
     steps:
       - uses: actions/checkout@v3
       - name: Generate TLS certificates
         run: |
-          extras/ci/generate_certs.sh "$CH_SSL_CA_CERTIFICATE" "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CLIENT_CERTIFICATE" "$CH_SSL_CLIENT_PRIVATE_KEY" "$CH_SSL_CLIENT_P12"
-          # server needs access to those
-          chmod 644 "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CA_CERTIFICATE"
+          extras/ci/generate_certs.sh tls
       # NOTE:
       # - we cannot use "services" because they are executed before the steps, i.e. repository checkout.
       # - "job.container.network" is empty, hence "host"
@@ -74,12 +62,7 @@ jobs:
         run: docker run
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
           -v ./extras/ci/users-overrides.yaml:/etc/clickhouse-server/users.d/overrides.yaml
-          -v $CH_SSL_CERTIFICATE:/etc/clickhouse-server/config.d/server.crt
-          -v $CH_SSL_PRIVATE_KEY:/etc/clickhouse-server/config.d/server.key
-          -v $CH_SSL_CA_CERTIFICATE:/etc/clickhouse-server/config.d/ca.pem
-          -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
-          -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
-          -e CH_SSL_CA_CERTIFICATE=/etc/clickhouse-server/config.d/ca.pem
+          -v ./tls:/etc/clickhouse-server/tls
           -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
           --name clickhouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,12 @@ jobs:
           - tcp://localhost:9440?skip_verify=true
           # we don't need skip_verify when we pass CA cert
           - tcp://localhost:9440?ca_certificate=/tmp/ca.pem
-          # auth via mTLS
-          - tcp://tls@localhost:9440?ca_certificate=/tmp/ca.pem&certificate_file=/tmp/client.crt&private_key_file=/tmp/client.key
+        # mTLS
+        include:
+          - feature: tls-native-tls
+            database_url: tcp://tls@localhost:9440?ca_certificate=/tmp/ca.pem&tls_identity=/tmp/client.p12
+          - feature: tls-rustls
+            database_url: tcp://tls@localhost:9440?ca_certificate=/tmp/ca.pem&certificate_file=/tmp/client.crt&private_key_file=/tmp/client.key
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
@@ -54,11 +58,12 @@ jobs:
       CH_SSL_PRIVATE_KEY: /tmp/server.key
       CH_SSL_CLIENT_PRIVATE_KEY: /tmp/client.key
       CH_SSL_CLIENT_CERTIFICATE: /tmp/client.crt
+      CH_SSL_CLIENT_P12: /tmp/client.p12
     steps:
       - uses: actions/checkout@v3
       - name: Generate TLS certificates
         run: |
-          extras/ci/generate_certs.sh "$CH_SSL_CA_CERTIFICATE" "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CLIENT_CERTIFICATE" "$CH_SSL_CLIENT_PRIVATE_KEY"
+          extras/ci/generate_certs.sh "$CH_SSL_CA_CERTIFICATE" "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CLIENT_CERTIFICATE" "$CH_SSL_CLIENT_PRIVATE_KEY" "$CH_SSL_CLIENT_P12"
           # server needs access to those
           chmod 644 "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CA_CERTIFICATE"
       # NOTE:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           - tls-rustls
         options:
           - skip_verify=true
-          - certificate=/tmp/ca.pem
+          - ca_certificate=/tmp/ca.pem
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,23 +37,30 @@ jobs:
         feature:
           - tls-native-tls
           - tls-rustls
-        options:
-          - skip_verify=true
-          - ca_certificate=/tmp/ca.pem
+        database_url:
+          # for TLS we need skip_verify for self-signed certificate
+          - tcp://localhost:9440?skip_verify=true
+          # we don't need skip_verify when we pass CA cert
+          - tcp://localhost:9440?ca_certificate=/tmp/ca.pem
+          # auth via mTLS
+          - tcp://tls@localhost:9440?ca_certificate=/tmp/ca.pem&certificate_file=/tmp/client.crt&private_key_file=/tmp/client.key
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
       # NOTE: sometimes for native-tls default connection_timeout (500ms) is not enough, interestingly that for rustls it is OK.
-      DATABASE_URL: "tcp://localhost:9440?compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&${{ matrix.options }}&connection_timeout=5s"
+      DATABASE_URL: ${{ matrix.database_url }}&compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&connection_timeout=5s
       CH_SSL_CA_CERTIFICATE: /tmp/ca.pem
       CH_SSL_CERTIFICATE: /tmp/server.crt
       CH_SSL_PRIVATE_KEY: /tmp/server.key
+      CH_SSL_CLIENT_PRIVATE_KEY: /tmp/client.key
+      CH_SSL_CLIENT_CERTIFICATE: /tmp/client.crt
     steps:
       - uses: actions/checkout@v3
       - name: Generate TLS certificates
         run: |
-          extras/ci/generate_certs.sh "$CH_SSL_CA_CERTIFICATE" "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY"
-          chmod 644 "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY"
+          extras/ci/generate_certs.sh "$CH_SSL_CA_CERTIFICATE" "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CLIENT_CERTIFICATE" "$CH_SSL_CLIENT_PRIVATE_KEY"
+          # server needs access to those
+          chmod 644 "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY" "$CH_SSL_CA_CERTIFICATE"
       # NOTE:
       # - we cannot use "services" because they are executed before the steps, i.e. repository checkout.
       # - "job.container.network" is empty, hence "host"
@@ -61,10 +68,13 @@ jobs:
       - name: Run clickhouse-server
         run: docker run
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
+          -v ./extras/ci/users-overrides.yaml:/etc/clickhouse-server/users.d/overrides.yaml
           -v $CH_SSL_CERTIFICATE:/etc/clickhouse-server/config.d/server.crt
           -v $CH_SSL_PRIVATE_KEY:/etc/clickhouse-server/config.d/server.key
+          -v $CH_SSL_CA_CERTIFICATE:/etc/clickhouse-server/config.d/ca.pem
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
+          -e CH_SSL_CA_CERTIFICATE=/etc/clickhouse-server/config.d/ca.pem
           -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
           --name clickhouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-  build-native-tls:
+  build-tls:
+    strategy:
+      matrix:
+        feature:
+          - tls-native-tls
+          - tls-rustls
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
@@ -54,34 +59,6 @@ jobs:
           --publish 9440:9440
           clickhouse/clickhouse-server
       - name: Build
-        run: cargo build --features tls-native-tls --verbose
+        run: cargo build --features ${{ matrix.feature }} --verbose
       - name: Run tests
-        run: cargo test --features tls-native-tls --verbose
-
-  build-rustls:
-    runs-on: ubuntu-latest
-    env:
-      # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
-      DATABASE_URL: "tcp://localhost:9440?compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&skip_verify=true"
-    steps:
-      - uses: actions/checkout@v3
-      # NOTE:
-      # - we cannot use "services" because they are executed before the steps, i.e. repository checkout.
-      # - "job.container.network" is empty, hence "host"
-      # - github actions does not support YAML anchors (sigh)
-      - name: Run clickhouse-server
-        run: docker run
-          -v ./extras/ci/generate_certs.sh:/docker-entrypoint-initdb.d/generate_certs.sh
-          -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
-          -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
-          -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
-          -e CLICKHOUSE_SKIP_USER_SETUP=1
-          --network host
-          --rm
-          --detach
-          --publish 9440:9440
-          clickhouse/clickhouse-server
-      - name: Build
-        run: cargo build --features tls-rustls --verbose
-      - name: Run tests
-        run: cargo test --features tls-rustls --verbose
+        run: cargo test --features ${{ matrix.feature }} --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           - tls-rustls
         options:
           - skip_verify=true
-          - certificate=$CH_SSL_CERTIFICATE
+          - certificate=/etc/clickhouse-server/config.d/ca.pem
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
@@ -55,6 +55,7 @@ jobs:
         run: docker run
           -v ./extras/ci/generate_certs.sh:/docker-entrypoint-initdb.d/generate_certs.sh
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
+          -e CH_SSL_CA_CERTIFICATE=/etc/clickhouse-server/config.d/ca.pem
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
           -e CLICKHOUSE_SKIP_USER_SETUP=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         image: clickhouse/clickhouse-server
         ports:
           - 9000:9000
+        env:
+          CLICKHOUSE_SKIP_USER_SETUP: 1
     steps:
       - uses: actions/checkout@v3
       - name: Build
@@ -45,6 +47,7 @@ jobs:
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
+          -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
           --rm
           --detach
@@ -72,6 +75,7 @@ jobs:
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
+          -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
           --rm
           --detach

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,27 +39,35 @@ jobs:
           - tls-rustls
         options:
           - skip_verify=true
-          - certificate=/etc/clickhouse-server/config.d/ca.pem
+          - certificate=/tmp/ca.pem
     runs-on: ubuntu-latest
     env:
       # NOTE: not all tests "secure" aware, so let's define DATABASE_URL explicitly
       # NOTE: sometimes for native-tls default connection_timeout (500ms) is not enough, interestingly that for rustls it is OK.
       DATABASE_URL: "tcp://localhost:9440?compression=lz4&ping_timeout=2s&retry_timeout=3s&secure=true&${{ matrix.options }}&connection_timeout=5s"
+      CH_SSL_CA_CERTIFICATE: /tmp/ca.pem
+      CH_SSL_CERTIFICATE: /tmp/server.crt
+      CH_SSL_PRIVATE_KEY: /tmp/server.key
     steps:
       - uses: actions/checkout@v3
+      - name: Generate TLS certificates
+        run: |
+          extras/ci/generate_certs.sh "$CH_SSL_CA_CERTIFICATE" "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY"
+          chmod 644 "$CH_SSL_CERTIFICATE" "$CH_SSL_PRIVATE_KEY"
       # NOTE:
       # - we cannot use "services" because they are executed before the steps, i.e. repository checkout.
       # - "job.container.network" is empty, hence "host"
       # - github actions does not support YAML anchors (sigh)
       - name: Run clickhouse-server
         run: docker run
-          -v ./extras/ci/generate_certs.sh:/docker-entrypoint-initdb.d/generate_certs.sh
           -v ./extras/ci/overrides.xml:/etc/clickhouse-server/config.d/overrides.xml
-          -e CH_SSL_CA_CERTIFICATE=/etc/clickhouse-server/config.d/ca.pem
+          -v $CH_SSL_CERTIFICATE:/etc/clickhouse-server/config.d/server.crt
+          -v $CH_SSL_PRIVATE_KEY:/etc/clickhouse-server/config.d/server.key
           -e CH_SSL_CERTIFICATE=/etc/clickhouse-server/config.d/server.crt
           -e CH_SSL_PRIVATE_KEY=/etc/clickhouse-server/config.d/server.key
           -e CLICKHOUSE_SKIP_USER_SETUP=1
           --network host
+          --name clickhouse
           --rm
           --detach
           --publish 9440:9440

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - async-await
+      - next
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ for the most common use cases. The following features are available.
 
 - `tokio_io` *(enabled by default)* — I/O based on [Tokio](https://tokio.rs/).
 - `async_std` — I/O based on [async-std](https://async.rs/) (doesn't work together with `tokio_io`).
-- `tls` — TLS support (allowed only with `tokio_io`).
+- `tls` — TLS support (allowed only with `tokio_io` and one of TLS libraries, under `tls-rustls` or `tls-native-tls` features).
+
+### TLS
+
+- `skip_verify` - do not verify the server certificate (**insecure**)
+- `ca_certificate` - instead of `skip_verify` it is better to pass CA certificate explicitly (in case of self-signed certificates).
+- `client_certificate`/`client_private_key` - authentication using TLS certificates (mTLS) (see [ClickHouse documentation](https://clickhouse.com/docs/operations/external-authenticators/ssl-x509) for more info)
 
 ## Example
 

--- a/extras/ci/generate_certs.sh
+++ b/extras/ci/generate_certs.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-crt=$CH_SSL_CERTIFICATE
-key=$CH_SSL_PRIVATE_KEY
-ca_crt=$CH_SSL_CA_CERTIFICATE
+ca_crt=${1:-"$CH_SSL_CA_CERTIFICATE"} && shift
+crt=${1-:"$CH_SSL_CERTIFICATE"} && shift
+key=${1-:"$CH_SSL_PRIVATE_KEY"} && shift
 
-ca_key=${CH_SSL_CA_CERTIFICATE/.pem/.key}
+ca_key=${ca_crt/.pem/.key}
 csr=${key/.key/.csr}
 ext=${key/.key/.ext}
 
@@ -27,5 +27,3 @@ EOL
 
 openssl x509 -req -in "$csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$crt" -days 825 -sha256 -extfile "$ext"
 openssl verify -CAfile "$ca_crt" "$crt"
-
-chown clickhouse:clickhouse "$crt" "$key" "$ca_crt" "$ca_key" "$csr" "$ext"

--- a/extras/ci/generate_certs.sh
+++ b/extras/ci/generate_certs.sh
@@ -4,6 +4,9 @@ ca_crt=${1:-"$CH_SSL_CA_CERTIFICATE"} && shift
 crt=${1-:"$CH_SSL_CERTIFICATE"} && shift
 key=${1-:"$CH_SSL_PRIVATE_KEY"} && shift
 
+client_crt=${1-:"$CH_SSL_CLIENT_CERTIFICATE"} && shift
+client_key=${1-:"$CH_SSL_CLIENT_PRIVATE_KEY"} && shift
+
 ca_key=${ca_crt/.pem/.key}
 csr=${key/.key/.csr}
 ext=${key/.key/.ext}
@@ -27,3 +30,20 @@ EOL
 
 openssl x509 -req -in "$csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$crt" -days 825 -sha256 -extfile "$ext"
 openssl verify -CAfile "$ca_crt" "$crt"
+
+client_csr=${client_key/.key/.csr}
+client_ext=${client_key/.key/.ext}
+cat > "$client_ext" <<EOL
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature
+extendedKeyUsage = clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+EOL
+
+openssl genrsa -out "$client_key" 2048
+openssl req -new -key "$client_key" -out "$client_csr" -subj "/C=US/ST=DevState/O=DevOrg/CN=MyClient"
+openssl x509 -req -in "$client_csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$client_crt" -days 3650 -sha256 -extfile "$client_ext"
+openssl verify -CAfile "$ca_crt" "$client_crt"

--- a/extras/ci/generate_certs.sh
+++ b/extras/ci/generate_certs.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 
-ca_crt=${1:-"$CH_SSL_CA_CERTIFICATE"} && shift
-crt=${1-:"$CH_SSL_CERTIFICATE"} && shift
-key=${1-:"$CH_SSL_PRIVATE_KEY"} && shift
+out=$1 && shift
+mkdir -p "$out"
+cd "$out"
 
-client_crt=${1-:"$CH_SSL_CLIENT_CERTIFICATE"} && shift
-client_key=${1-:"$CH_SSL_CLIENT_PRIVATE_KEY"} && shift
-client_p12=${1-:"$CH_SSL_CLIENT_P12"} && shift
+#
+# CA
+#
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.pem -subj "/C=US/ST=DevState/O=DevOrg/CN=MyDevCA"
 
-ca_key=${ca_crt/.pem/.key}
-csr=${key/.key/.csr}
-ext=${key/.key/.ext}
+#
+# server
+#
+openssl genrsa -out server.key 2048
+openssl req -new -key server.key -out server.csr -subj "/C=US/ST=DevState/O=DevOrg/CN=localhost"
 
-openssl genrsa -out "$ca_key" 4096
-openssl req -x509 -new -nodes -key "$ca_key" -sha256 -days 3650 -out "$ca_crt" -subj "/C=US/ST=DevState/O=DevOrg/CN=MyDevCA"
-
-openssl genrsa -out "$key" 2048
-openssl req -new -key "$key" -out "$csr" -subj "/C=US/ST=DevState/O=DevOrg/CN=localhost"
-
-cat > "$ext" <<EOL
+cat > server.ext <<EOL
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, keyEncipherment
@@ -29,12 +27,13 @@ subjectAltName = @alt_names
 DNS.1 = localhost
 EOL
 
-openssl x509 -req -in "$csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$crt" -days 825 -sha256 -extfile "$ext"
-openssl verify -CAfile "$ca_crt" "$crt"
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out server.crt -days 825 -sha256 -extfile server.ext
+openssl verify -CAfile ca.pem server.crt
 
-client_csr=${client_key/.key/.csr}
-client_ext=${client_key/.key/.ext}
-cat > "$client_ext" <<EOL
+#
+# client
+#
+cat > client.ext <<EOL
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature
 extendedKeyUsage = clientAuth
@@ -44,9 +43,10 @@ subjectAltName = @alt_names
 DNS.1 = localhost
 EOL
 
-openssl genrsa -out "$client_key" 2048
-openssl req -new -key "$client_key" -out "$client_csr" -subj "/C=US/ST=DevState/O=DevOrg/CN=MyClient"
-openssl x509 -req -in "$client_csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$client_crt" -days 3650 -sha256 -extfile "$client_ext"
-openssl verify -CAfile "$ca_crt" "$client_crt"
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr -subj "/C=US/ST=DevState/O=DevOrg/CN=MyClient"
+openssl x509 -req -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out client.crt -days 3650 -sha256 -extfile client.ext
+openssl verify -CAfile ca.pem client.crt
 
-openssl pkcs12 -export -inkey "$client_key" -in "$client_crt" -certfile "$ca_crt" -out "$client_p12" -passout pass:
+# server needs access to those
+chmod 644 ca.pem server.key server.crt

--- a/extras/ci/generate_certs.sh
+++ b/extras/ci/generate_certs.sh
@@ -2,6 +2,30 @@
 
 crt=$CH_SSL_CERTIFICATE
 key=$CH_SSL_PRIVATE_KEY
+ca_crt=$CH_SSL_CA_CERTIFICATE
 
-openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout "$key" -out "$crt"
-chown clickhouse:clickhouse "$crt" "$key"
+ca_key=${CH_SSL_CA_CERTIFICATE/.pem/.key}
+csr=${key/.key/.csr}
+ext=${key/.key/.ext}
+
+openssl genrsa -out "$ca_key" 4096
+openssl req -x509 -new -nodes -key "$ca_key" -sha256 -days 3650 -out "$ca_crt" -subj "/C=US/ST=DevState/O=DevOrg/CN=MyDevCA"
+
+openssl genrsa -out "$key" 2048
+openssl req -new -key "$key" -out "$csr" -subj "/C=US/ST=DevState/O=DevOrg/CN=localhost"
+
+cat > "$ext" <<EOL
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+EOL
+
+openssl x509 -req -in "$csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$crt" -days 825 -sha256 -extfile "$ext"
+openssl verify -CAfile "$ca_crt" "$crt"
+
+chown clickhouse:clickhouse "$crt" "$key" "$ca_crt" "$ca_key" "$csr" "$ext"

--- a/extras/ci/generate_certs.sh
+++ b/extras/ci/generate_certs.sh
@@ -6,6 +6,7 @@ key=${1-:"$CH_SSL_PRIVATE_KEY"} && shift
 
 client_crt=${1-:"$CH_SSL_CLIENT_CERTIFICATE"} && shift
 client_key=${1-:"$CH_SSL_CLIENT_PRIVATE_KEY"} && shift
+client_p12=${1-:"$CH_SSL_CLIENT_P12"} && shift
 
 ca_key=${ca_crt/.pem/.key}
 csr=${key/.key/.csr}
@@ -47,3 +48,5 @@ openssl genrsa -out "$client_key" 2048
 openssl req -new -key "$client_key" -out "$client_csr" -subj "/C=US/ST=DevState/O=DevOrg/CN=MyClient"
 openssl x509 -req -in "$client_csr" -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial -out "$client_crt" -days 3650 -sha256 -extfile "$client_ext"
 openssl verify -CAfile "$ca_crt" "$client_crt"
+
+openssl pkcs12 -export -inkey "$client_key" -in "$client_crt" -certfile "$ca_crt" -out "$client_p12" -passout pass:

--- a/extras/ci/overrides.xml
+++ b/extras/ci/overrides.xml
@@ -3,7 +3,8 @@
         <server>
             <certificateFile from_env="CH_SSL_CERTIFICATE" replace="1"></certificateFile>
             <privateKeyFile from_env="CH_SSL_PRIVATE_KEY" replace="1"></privateKeyFile>
-            <verificationMode>none</verificationMode>
+            <caConfig from_env="CH_SSL_CA_CERTIFICATE" replace="1"></caConfig>
+            <verificationMode>relaxed</verificationMode>
             <loadDefaultCAFile>true</loadDefaultCAFile>
             <cacheSessions>true</cacheSessions>
             <disableProtocols>sslv2,sslv3</disableProtocols>

--- a/extras/ci/overrides.xml
+++ b/extras/ci/overrides.xml
@@ -1,9 +1,9 @@
 <clickhouse>
     <openSSL>
         <server>
-            <certificateFile from_env="CH_SSL_CERTIFICATE" replace="1"></certificateFile>
-            <privateKeyFile from_env="CH_SSL_PRIVATE_KEY" replace="1"></privateKeyFile>
-            <caConfig from_env="CH_SSL_CA_CERTIFICATE" replace="1"></caConfig>
+            <certificateFile>/etc/clickhouse-server/tls/server.crt</certificateFile>
+            <privateKeyFile>/etc/clickhouse-server/tls/server.key</privateKeyFile>
+            <caConfig>/etc/clickhouse-server/tls/ca.pem</caConfig>
             <verificationMode>relaxed</verificationMode>
             <loadDefaultCAFile>true</loadDefaultCAFile>
             <cacheSessions>true</cacheSessions>

--- a/extras/ci/users-overrides.yaml
+++ b/extras/ci/users-overrides.yaml
@@ -1,0 +1,6 @@
+---
+users:
+  tls:
+    ssl_certificates:
+      subject_alt_name:
+      - DNS:localhost

--- a/src/connecting_stream.rs
+++ b/src/connecting_stream.rs
@@ -104,7 +104,7 @@ impl State {
         State::Tcp(TcpState::Fail(Some(conn_error)))
     }
 
-    #[cfg(feature = "_tls")]
+    #[cfg(feature = "tls-rustls")]
     fn tls_err(e: TlsError) -> Self {
         State::Tls(TlsState::Fail(Some(ConnectionError::TlsError(e))))
     }
@@ -239,6 +239,9 @@ impl ConnectingStream {
                 if let Some(certificate) = options.ca_certificate.clone() {
                     let native_cert = native_tls::Certificate::from(certificate);
                     builder.add_root_certificate(native_cert);
+                }
+                if let Some(identity) = options.tls_identity.clone() {
+                    builder.identity(identity.into());
                 }
 
                 Self {

--- a/src/connecting_stream.rs
+++ b/src/connecting_stream.rs
@@ -231,7 +231,7 @@ impl ConnectingStream {
             Some(host) => {
                 let mut builder = TlsConnector::builder();
                 builder.danger_accept_invalid_certs(options.skip_verify);
-                if let Some(certificate) = options.certificate.clone() {
+                if let Some(certificate) = options.ca_certificate.clone() {
                     let native_cert = native_tls::Certificate::from(certificate);
                     builder.add_root_certificate(native_cert);
                 }
@@ -273,7 +273,7 @@ impl ConnectingStream {
                             .iter()
                             .cloned()
                     );
-                    if let Some(certificates) = options.certificate.clone() {
+                    if let Some(certificates) = options.ca_certificate.clone() {
                         for certificate in
                             Into::<Vec<rustls::pki_types::CertificateDer<'static>>>::into(
                                 certificates,

--- a/src/connecting_stream.rs
+++ b/src/connecting_stream.rs
@@ -105,6 +105,11 @@ impl State {
     }
 
     #[cfg(feature = "_tls")]
+    fn tls_err(e: TlsError) -> Self {
+        State::Tls(TlsState::Fail(Some(ConnectionError::TlsError(e))))
+    }
+
+    #[cfg(feature = "_tls")]
     fn tls_host_err() -> Self {
         State::Tls(TlsState::Fail(Some(ConnectionError::TlsHostNotProvided)))
     }
@@ -261,11 +266,10 @@ impl ConnectingStream {
                 state: State::tls_host_err(),
             },
             Some(host) => {
-                let config = if options.skip_verify {
+                let builder = if options.skip_verify {
                     ClientConfig::builder()
                         .dangerous()
                         .with_custom_certificate_verifier(Arc::new(DummyTlsVerifier))
-                        .with_no_client_auth()
                 } else {
                     let mut cert_store = RootCertStore::empty();
                     cert_store.extend(
@@ -293,7 +297,21 @@ impl ConnectingStream {
                     }
                     ClientConfig::builder()
                         .with_root_certificates(cert_store)
-                        .with_no_client_auth()
+                };
+                let config = if let Some(certificate_file) = options.certificate_file.clone() {
+                    if let Some(private_key_file) = options.private_key_file.clone() {
+                        builder.with_client_auth_cert(certificate_file.into(), private_key_file.into())
+                    } else {
+                        Ok(builder.with_no_client_auth())
+                    }
+                } else {
+                    Ok(builder.with_no_client_auth())
+                };
+                let config = match config {
+                    Ok(config) => config,
+                    Err(err) => {
+                        return Self { state: State::tls_err(err) };
+                    },
                 };
                 Self {
                     state: State::tls_wait(Box::pin(async move {

--- a/src/connecting_stream.rs
+++ b/src/connecting_stream.rs
@@ -35,6 +35,8 @@ use crate::{errors::ConnectionError, io::Stream as InnerStream, Options};
 use tokio_native_tls::TlsStream;
 #[cfg(feature = "tls-rustls")]
 use tokio_rustls::client::TlsStream;
+#[cfg(feature = "_tls")]
+use crate::types::ClientTlsIdentity;
 
 type Result<T> = std::result::Result<T, ConnectionError>;
 
@@ -130,6 +132,7 @@ pub(crate) struct ConnectingStream {
     state: State,
 }
 
+#[cfg(feature = "tls-rustls")]
 #[derive(Debug)]
 struct DummyTlsVerifier;
 
@@ -240,8 +243,9 @@ impl ConnectingStream {
                     let native_cert = native_tls::Certificate::from(certificate);
                     builder.add_root_certificate(native_cert);
                 }
-                if let Some(identity) = options.tls_identity.clone() {
-                    builder.identity(identity.into());
+                if let Some(identity) = &options.client_tls_identity {
+                    let ClientTlsIdentity::Pkcs(pkcs) = identity;
+                    builder.identity(pkcs.clone());
                 }
 
                 Self {
@@ -301,12 +305,9 @@ impl ConnectingStream {
                     ClientConfig::builder()
                         .with_root_certificates(cert_store)
                 };
-                let config = if let Some(certificate_file) = options.certificate_file.clone() {
-                    if let Some(private_key_file) = options.private_key_file.clone() {
-                        builder.with_client_auth_cert(certificate_file.into(), private_key_file.into())
-                    } else {
-                        Ok(builder.with_no_client_auth())
-                    }
+                let config = if let Some(identity) = &options.client_tls_identity {
+                    let ClientTlsIdentity::Pem { key, certs } = identity;
+                    builder.with_client_auth_cert(certs.clone().into(), key.clone_key())
                 } else {
                     Ok(builder.with_no_client_auth())
                 };

--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -287,6 +287,15 @@ impl Stream for ClickhouseTransport {
         }
 
         if *this.done {
+            // We still have may have something in buffer, since the client may read something
+            // first, and only after the server will close the connection, likely in case of
+            // exception, let's try to parse it here
+            if !this.rd.is_empty() {
+                if let Poll::Ready(ret) = this.try_parse_msg()? {
+                    return Poll::Ready(ret.map(Ok));
+                }
+            }
+
             return Poll::Ready(None);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl ClientHandle {
         }
 
         self.inner = h;
-        self.context.server_info = info.unwrap();
+        self.context.server_info = info.ok_or(Error::Other("Missing Hello/Exception packet".into()))?;
         Ok(())
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -21,6 +21,8 @@ pub use self::{
     value::Value,
     value_ref::ValueRef,
 };
+#[cfg(feature = "_tls")]
+pub use self::options::ClientTlsIdentity;
 
 pub(crate) use self::{
     cmd::Cmd,

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -12,6 +12,9 @@ use crate::errors::{Error, Result, UrlError};
 use percent_encoding::percent_decode;
 use url::Url;
 
+#[cfg(feature = "tls-rustls")]
+use rustls::pki_types::pem::PemObject;
+
 const DEFAULT_MIN_CONNS: usize = 10;
 
 const DEFAULT_MAX_CONNS: usize = 20;
@@ -177,6 +180,44 @@ pub fn load_certificate(file: &str) -> Result<Certificate> {
     }
 }
 
+/// Private key for rustls.
+#[cfg(feature = "tls-rustls")]
+#[derive(Clone)]
+pub struct PrivateKey(Arc<rustls::pki_types::PrivateKeyDer<'static>>);
+#[cfg(feature = "tls-rustls")]
+impl PrivateKey {
+    pub fn from_pem(pem: &[u8]) -> Result<Self> {
+        let key = rustls::pki_types::PrivateKeyDer::from_pem_slice(&mut pem.as_ref()).map_err(|_| UrlError::Invalid)?;
+        Ok(Self(Arc::new(key)))
+    }
+}
+#[cfg(feature = "tls-rustls")]
+impl From<PrivateKey> for rustls::pki_types::PrivateKeyDer<'static> {
+    fn from(value: PrivateKey) -> Self {
+        rustls::pki_types::PrivateKeyDer::clone_key(value.0.as_ref())
+    }
+}
+
+#[cfg(feature = "_tls")]
+impl fmt::Debug for PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[Private Key]")
+    }
+}
+
+#[cfg(feature = "_tls")]
+impl PartialEq for PrivateKey {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "_tls")]
+pub fn load_private_key(file: &str) -> Result<PrivateKey> {
+    let data = fs::read(file)?;
+    PrivateKey::from_pem(&data)
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub enum SettingType {
     String(String),
@@ -302,6 +343,14 @@ pub struct Options {
     #[cfg(feature = "_tls")]
     pub(crate) ca_certificate: Option<Certificate>,
 
+    /// Certificate for authorization.
+    #[cfg(feature = "_tls")]
+    pub(crate) certificate_file: Option<Certificate>,
+
+    /// Private key for certificate.
+    #[cfg(feature = "_tls")]
+    pub(crate) private_key_file: Option<PrivateKey>,
+
     /// Query settings
     pub(crate) settings: HashMap<String, SettingValue>,
 
@@ -357,6 +406,10 @@ impl Default for Options {
             skip_verify: false,
             #[cfg(feature = "_tls")]
             ca_certificate: None,
+            #[cfg(feature = "_tls")]
+            certificate_file: None,
+            #[cfg(feature = "_tls")]
+            private_key_file: None,
             settings: HashMap::new(),
             alt_hosts: Vec::new(),
         }
@@ -511,6 +564,18 @@ impl Options {
         => ca_certificate: Option<Certificate>
     }
 
+    #[cfg(feature = "_tls")]
+    property! {
+        /// Certificate for authorization.
+        => certificate_file: Option<Certificate>
+    }
+
+    #[cfg(feature = "_tls")]
+    property! {
+        /// Private key for certificate.
+        => private_key_file: Option<PrivateKey>
+    }
+
     property! {
         /// Query settings
         => settings: HashMap<String, SettingValue>
@@ -604,6 +669,10 @@ where
             "skip_verify" => options.skip_verify = parse_param(key, value, bool::from_str)?,
             #[cfg(feature = "_tls")]
             "ca_certificate" => options.ca_certificate = Some(parse_param(key, value, load_certificate)?),
+            #[cfg(feature = "_tls")]
+            "certificate_file" => options.certificate_file = Some(parse_param(key, value, load_certificate)?),
+            #[cfg(feature = "_tls")]
+            "private_key_file" => options.private_key_file = Some(parse_param(key, value, load_private_key)?),
             "alt_hosts" => options.alt_hosts = parse_param(key, value, parse_hosts)?,
             _ => {
                 let value = SettingType::String(value.to_string());

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     fmt,
+    fs,
     str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,
@@ -166,6 +167,16 @@ impl PartialEq for Certificate {
     }
 }
 
+#[cfg(feature = "_tls")]
+pub fn load_certificate(file: &str) -> Result<Certificate> {
+    let data = fs::read(file)?;
+    if file.ends_with(".der") || file.ends_with(".cer") {
+        Certificate::from_der(&data)
+    } else {
+        Certificate::from_pem(&data)
+    }
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub enum SettingType {
     String(String),
@@ -315,6 +326,7 @@ impl fmt::Debug for Options {
             .field("connection_timeout", &self.connection_timeout)
             .field("settings", &self.settings)
             .field("alt_hosts", &self.alt_hosts)
+            .field("certificate", &self.certificate)
             .finish()
     }
 }
@@ -590,6 +602,8 @@ where
             "secure" => options.secure = parse_param(key, value, bool::from_str)?,
             #[cfg(feature = "_tls")]
             "skip_verify" => options.skip_verify = parse_param(key, value, bool::from_str)?,
+            #[cfg(feature = "_tls")]
+            "certificate" => options.certificate = Some(parse_param(key, value, load_certificate)?),
             "alt_hosts" => options.alt_hosts = parse_param(key, value, parse_hosts)?,
             _ => {
                 let value = SettingType::String(value.to_string());

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -2,11 +2,12 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     fmt,
-    fs,
     str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,
 };
+#[cfg(feature = "_tls")]
+use std::fs;
 
 use crate::errors::{Error, Result, UrlError};
 use percent_encoding::percent_decode;
@@ -180,74 +181,50 @@ pub fn load_certificate(file: &str) -> Result<Certificate> {
     }
 }
 
-/// Private key for rustls.
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "_tls")]
 #[derive(Clone)]
-pub struct PrivateKey(Arc<rustls::pki_types::PrivateKeyDer<'static>>);
-#[cfg(feature = "tls-rustls")]
-impl PrivateKey {
-    pub fn from_pem(pem: &[u8]) -> Result<Self> {
-        let key = rustls::pki_types::PrivateKeyDer::from_pem_slice(&mut pem.as_ref()).map_err(|_| UrlError::Invalid)?;
-        Ok(Self(Arc::new(key)))
-    }
-}
-#[cfg(feature = "tls-rustls")]
-impl From<PrivateKey> for rustls::pki_types::PrivateKeyDer<'static> {
-    fn from(value: PrivateKey) -> Self {
-        rustls::pki_types::PrivateKeyDer::clone_key(value.0.as_ref())
-    }
-}
-#[cfg(feature = "tls-rustls")]
-impl fmt::Debug for PrivateKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "[Private Key]")
-    }
-}
-#[cfg(feature = "tls-rustls")]
-impl PartialEq for PrivateKey {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-#[cfg(feature = "tls-rustls")]
-pub fn load_private_key(file: &str) -> Result<PrivateKey> {
-    let data = fs::read(file)?;
-    PrivateKey::from_pem(&data)
+pub enum ClientTlsIdentity {
+    #[cfg(feature = "tls-rustls")]
+    Pem {
+        key: Arc<rustls::pki_types::PrivateKeyDer<'static>>,
+        certs: Certificate,
+    },
+    #[cfg(feature = "tls-native-tls")]
+    Pkcs(native_tls::Identity),
 }
 
-/// Identity for mTLS for native-tls
-#[cfg(feature = "tls-native-tls")]
-#[derive(Clone)]
-pub struct TlsIdentity(Arc<native_tls::Identity>);
-#[cfg(feature = "tls-native-tls")]
-impl TlsIdentity {
-    pub fn from_pkcs12_der(der: &[u8]) -> Result<Self> {
-        // FIXME: support password
-        Ok(Self(Arc::new(native_tls::Identity::from_pkcs12(der, "").map_err(|_| UrlError::Invalid)?)))
+#[cfg(feature = "_tls")]
+impl ClientTlsIdentity {
+    #[cfg(feature = "tls-rustls")]
+    pub fn load(cert_path: &str, key_path: &str) -> Result<Self> {
+        let key = rustls::pki_types::PrivateKeyDer::from_pem_slice(fs::read(key_path)?.as_ref())
+            .map_err(|e| format!("Cannot read private key from {}: {}", key_path, e))?;
+        let key = Arc::new(key);
+        let certs = load_certificate(cert_path)?;
+        return Ok(Self::Pem{ key, certs });
+    }
+
+    #[cfg(feature = "tls-native-tls")]
+    pub fn load(cert_path: &str, key_path: &str) -> Result<Self> {
+        let identity = native_tls::Identity::from_pkcs8(
+            fs::read(cert_path)?.as_ref(),
+            fs::read(key_path)?.as_ref(),
+        ).map_err(|e| format!("Cannot load identity from {} and {}: {}", cert_path, key_path, e))?;
+        return Ok(Self::Pkcs(identity));
     }
 }
-#[cfg(feature = "tls-native-tls")]
-impl From<TlsIdentity> for native_tls::Identity {
-    fn from(value: TlsIdentity) -> Self {
-        value.0.as_ref().clone()
-    }
-}
-#[cfg(feature = "tls-native-tls")]
-impl fmt::Debug for TlsIdentity {
+
+#[cfg(feature = "_tls")]
+impl fmt::Debug for ClientTlsIdentity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "[Private Key]")
+        write!(f, "[Client Certificate]")
     }
 }
-#[cfg(feature = "tls-native-tls")]
-impl PartialEq for TlsIdentity {
+#[cfg(feature = "_tls")]
+impl PartialEq for ClientTlsIdentity {
     fn eq(&self, _other: &Self) -> bool {
         true
     }
-}
-#[cfg(feature = "tls-native-tls")]
-pub fn load_tls_identity(file: &str) -> Result<TlsIdentity> {
-    let data = fs::read(file)?;
-    TlsIdentity::from_pkcs12_der(&data)
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -375,16 +352,9 @@ pub struct Options {
     #[cfg(feature = "_tls")]
     pub(crate) ca_certificate: Option<Certificate>,
 
-    /// Certificate for authorization.
+    /// Authorization with certificate (mTLS).
     #[cfg(feature = "_tls")]
-    pub(crate) certificate_file: Option<Certificate>,
-
-    /// Private key for certificate.
-    /// TODO: merge private_key_file + certificate_file into client_tls_identity
-    #[cfg(feature = "tls-rustls")]
-    pub(crate) private_key_file: Option<PrivateKey>,
-    #[cfg(feature = "tls-native-tls")]
-    pub(crate) tls_identity: Option<TlsIdentity>,
+    pub(crate) client_tls_identity: Option<ClientTlsIdentity>,
 
     /// Query settings
     pub(crate) settings: HashMap<String, SettingValue>,
@@ -395,7 +365,8 @@ pub struct Options {
 
 impl fmt::Debug for Options {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Options")
+        let mut debug = f.debug_struct("Options");
+        let res = debug
             .field("addr", &self.addr)
             .field("database", &self.database)
             .field("compression", &self.compression)
@@ -409,9 +380,15 @@ impl fmt::Debug for Options {
             .field("ping_timeout", &self.ping_timeout)
             .field("connection_timeout", &self.connection_timeout)
             .field("settings", &self.settings)
-            .field("alt_hosts", &self.alt_hosts)
+            .field("alt_hosts", &self.alt_hosts);
+
+        #[cfg(feature = "_tls")]
+        res
+            .field("secure", &self.secure)
             .field("ca_certificate", &self.ca_certificate)
-            .finish()
+            .field("client_tls_identity", &self.client_tls_identity);
+
+        res.finish()
     }
 }
 
@@ -442,11 +419,7 @@ impl Default for Options {
             #[cfg(feature = "_tls")]
             ca_certificate: None,
             #[cfg(feature = "_tls")]
-            certificate_file: None,
-            #[cfg(feature = "tls-rustls")]
-            private_key_file: None,
-            #[cfg(feature = "tls-native-tls")]
-            tls_identity: None,
+            client_tls_identity: None,
             settings: HashMap::new(),
             alt_hosts: Vec::new(),
         }
@@ -603,20 +576,8 @@ impl Options {
 
     #[cfg(feature = "_tls")]
     property! {
-        /// Certificate for authorization.
-        => certificate_file: Option<Certificate>
-    }
-
-    #[cfg(feature = "tls-rustls")]
-    property! {
-        /// Private key for certificate.
-        => private_key_file: Option<PrivateKey>
-    }
-
-    #[cfg(feature = "tls-native-tls")]
-    property! {
-        /// Identity for mTLS.
-        => tls_identity: Option<TlsIdentity>
+        /// Authorization with certificate (mTLS).
+        => client_tls_identity: Option<ClientTlsIdentity>
     }
 
     property! {
@@ -683,6 +644,11 @@ fn set_params<'a, I>(options: &mut Options, iter: I) -> std::result::Result<(), 
 where
     I: Iterator<Item = (Cow<'a, str>, Cow<'a, str>)>,
 {
+    #[cfg(feature = "_tls")]
+    let mut client_certificate = None;
+    #[cfg(feature = "_tls")]
+    let mut client_private_key = None;
+
     for (key, value) in iter {
         match key.as_ref() {
             "pool_min" => options.pool_min = parse_param(key, value, usize::from_str)?,
@@ -713,11 +679,9 @@ where
             #[cfg(feature = "_tls")]
             "ca_certificate" => options.ca_certificate = Some(parse_param(key, value, load_certificate)?),
             #[cfg(feature = "_tls")]
-            "certificate_file" => options.certificate_file = Some(parse_param(key, value, load_certificate)?),
-            #[cfg(feature = "tls-rustls")]
-            "private_key_file" => options.private_key_file = Some(parse_param(key, value, load_private_key)?),
-            #[cfg(feature = "tls-native-tls")]
-            "tls_identity" => options.tls_identity = Some(parse_param(key, value, load_tls_identity)?),
+            "client_certificate" => client_certificate = Some(value),
+            #[cfg(feature = "_tls")]
+            "client_private_key" => client_private_key = Some(value),
             "alt_hosts" => options.alt_hosts = parse_param(key, value, parse_hosts)?,
             _ => {
                 let value = SettingType::String(value.to_string());
@@ -730,6 +694,17 @@ where
                 );
             }
         };
+    }
+
+    #[cfg(feature = "_tls")]
+    match (client_certificate, client_private_key) {
+        (Some(cert), Some(key)) => {
+            options.client_tls_identity = Some(ClientTlsIdentity::load(&cert, &key).map_err(|_| UrlError::Invalid)?);
+        }
+        (None, None) => {}
+        _ => {
+            return Err(UrlError::Invalid);
+        },
     }
 
     Ok(())

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -107,8 +107,8 @@ impl Certificate {
     }
 
     /// Parses a PEM-formatted X509 certificate.
-    pub fn from_pem(der: &[u8]) -> Result<Certificate> {
-        let inner = match native_tls::Certificate::from_pem(der) {
+    pub fn from_pem(pem: &[u8]) -> Result<Certificate> {
+        let inner = match native_tls::Certificate::from_pem(pem) {
             Ok(certificate) => certificate,
             Err(err) => return Err(Error::Other(err.to_string().into())),
         };
@@ -139,8 +139,8 @@ impl Certificate {
     }
 
     /// Parses a PEM-formatted X509 certificate.
-    pub fn from_pem(der: &[u8]) -> Result<Certificate> {
-        let certs = rustls_pemfile::certs(&mut der.as_ref())
+    pub fn from_pem(pem: &[u8]) -> Result<Certificate> {
+        let certs = rustls_pemfile::certs(&mut pem.as_ref())
             .map(|result| result.unwrap())
             .collect();
         Ok(Certificate(Arc::new(certs)))

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -298,9 +298,9 @@ pub struct Options {
     #[cfg(feature = "_tls")]
     pub(crate) skip_verify: bool,
 
-    /// An X509 certificate.
+    /// CA certificate.
     #[cfg(feature = "_tls")]
-    pub(crate) certificate: Option<Certificate>,
+    pub(crate) ca_certificate: Option<Certificate>,
 
     /// Query settings
     pub(crate) settings: HashMap<String, SettingValue>,
@@ -326,7 +326,7 @@ impl fmt::Debug for Options {
             .field("connection_timeout", &self.connection_timeout)
             .field("settings", &self.settings)
             .field("alt_hosts", &self.alt_hosts)
-            .field("certificate", &self.certificate)
+            .field("ca_certificate", &self.ca_certificate)
             .finish()
     }
 }
@@ -356,7 +356,7 @@ impl Default for Options {
             #[cfg(feature = "_tls")]
             skip_verify: false,
             #[cfg(feature = "_tls")]
-            certificate: None,
+            ca_certificate: None,
             settings: HashMap::new(),
             alt_hosts: Vec::new(),
         }
@@ -507,8 +507,8 @@ impl Options {
 
     #[cfg(feature = "_tls")]
     property! {
-        /// An X509 certificate.
-        => certificate: Option<Certificate>
+        /// CA certificate.
+        => ca_certificate: Option<Certificate>
     }
 
     property! {
@@ -603,7 +603,7 @@ where
             #[cfg(feature = "_tls")]
             "skip_verify" => options.skip_verify = parse_param(key, value, bool::from_str)?,
             #[cfg(feature = "_tls")]
-            "certificate" => options.certificate = Some(parse_param(key, value, load_certificate)?),
+            "ca_certificate" => options.ca_certificate = Some(parse_param(key, value, load_certificate)?),
             "alt_hosts" => options.alt_hosts = parse_param(key, value, parse_hosts)?,
             _ => {
                 let value = SettingType::String(value.to_string());

--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -197,25 +197,57 @@ impl From<PrivateKey> for rustls::pki_types::PrivateKeyDer<'static> {
         rustls::pki_types::PrivateKeyDer::clone_key(value.0.as_ref())
     }
 }
-
-#[cfg(feature = "_tls")]
+#[cfg(feature = "tls-rustls")]
 impl fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[Private Key]")
     }
 }
-
-#[cfg(feature = "_tls")]
+#[cfg(feature = "tls-rustls")]
 impl PartialEq for PrivateKey {
     fn eq(&self, _other: &Self) -> bool {
         true
     }
 }
-
-#[cfg(feature = "_tls")]
+#[cfg(feature = "tls-rustls")]
 pub fn load_private_key(file: &str) -> Result<PrivateKey> {
     let data = fs::read(file)?;
     PrivateKey::from_pem(&data)
+}
+
+/// Identity for mTLS for native-tls
+#[cfg(feature = "tls-native-tls")]
+#[derive(Clone)]
+pub struct TlsIdentity(Arc<native_tls::Identity>);
+#[cfg(feature = "tls-native-tls")]
+impl TlsIdentity {
+    pub fn from_pkcs12_der(der: &[u8]) -> Result<Self> {
+        // FIXME: support password
+        Ok(Self(Arc::new(native_tls::Identity::from_pkcs12(der, "").map_err(|_| UrlError::Invalid)?)))
+    }
+}
+#[cfg(feature = "tls-native-tls")]
+impl From<TlsIdentity> for native_tls::Identity {
+    fn from(value: TlsIdentity) -> Self {
+        value.0.as_ref().clone()
+    }
+}
+#[cfg(feature = "tls-native-tls")]
+impl fmt::Debug for TlsIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[Private Key]")
+    }
+}
+#[cfg(feature = "tls-native-tls")]
+impl PartialEq for TlsIdentity {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+#[cfg(feature = "tls-native-tls")]
+pub fn load_tls_identity(file: &str) -> Result<TlsIdentity> {
+    let data = fs::read(file)?;
+    TlsIdentity::from_pkcs12_der(&data)
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -348,8 +380,11 @@ pub struct Options {
     pub(crate) certificate_file: Option<Certificate>,
 
     /// Private key for certificate.
-    #[cfg(feature = "_tls")]
+    /// TODO: merge private_key_file + certificate_file into client_tls_identity
+    #[cfg(feature = "tls-rustls")]
     pub(crate) private_key_file: Option<PrivateKey>,
+    #[cfg(feature = "tls-native-tls")]
+    pub(crate) tls_identity: Option<TlsIdentity>,
 
     /// Query settings
     pub(crate) settings: HashMap<String, SettingValue>,
@@ -408,8 +443,10 @@ impl Default for Options {
             ca_certificate: None,
             #[cfg(feature = "_tls")]
             certificate_file: None,
-            #[cfg(feature = "_tls")]
+            #[cfg(feature = "tls-rustls")]
             private_key_file: None,
+            #[cfg(feature = "tls-native-tls")]
+            tls_identity: None,
             settings: HashMap::new(),
             alt_hosts: Vec::new(),
         }
@@ -570,10 +607,16 @@ impl Options {
         => certificate_file: Option<Certificate>
     }
 
-    #[cfg(feature = "_tls")]
+    #[cfg(feature = "tls-rustls")]
     property! {
         /// Private key for certificate.
         => private_key_file: Option<PrivateKey>
+    }
+
+    #[cfg(feature = "tls-native-tls")]
+    property! {
+        /// Identity for mTLS.
+        => tls_identity: Option<TlsIdentity>
     }
 
     property! {
@@ -671,8 +714,10 @@ where
             "ca_certificate" => options.ca_certificate = Some(parse_param(key, value, load_certificate)?),
             #[cfg(feature = "_tls")]
             "certificate_file" => options.certificate_file = Some(parse_param(key, value, load_certificate)?),
-            #[cfg(feature = "_tls")]
+            #[cfg(feature = "tls-rustls")]
             "private_key_file" => options.private_key_file = Some(parse_param(key, value, load_private_key)?),
+            #[cfg(feature = "tls-native-tls")]
+            "tls_identity" => options.tls_identity = Some(parse_param(key, value, load_tls_identity)?),
             "alt_hosts" => options.alt_hosts = parse_param(key, value, parse_hosts)?,
             _ => {
                 let value = SettingType::String(value.to_string());

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -806,7 +806,7 @@ mod test {
     #[test]
     fn test_size_of() {
         use std::mem;
-        assert_eq!(56, mem::size_of::<[Value; 1]>());
+        assert_eq!(64, mem::size_of::<[Value; 1]>());
     }
 
     #[test]


### PR DESCRIPTION
**Note: blocked by https://github.com/suharev7/clickhouse-rs/pull/226 hence draft for now**

mTLS (Mutual TLS, or mTLS for short, is a method for mutual authentication) allows you to authenticate on the server with client certificate.

Now `clickhouse-rs` supports it, for this you need to pass the following arguments for connection url:
- `ca_certificate`
- `client_certificate`
- `client_private_key`

Some other things:
- Support specifying TLS certificate via `ca_certificate` parameter in URL
- Add missing TLS fields for `Debug` trait
- Update section about TLS features in README
- Extend CI coverage for TLS
