### PR TITLE
Fix CityHash interface

### DIFF
--- a/clickhouse-rs-cityhash-sys/src/cc/city.cc
+++ b/clickhouse-rs-cityhash-sys/src/cc/city.cc
@@ -337,7 +337,7 @@ uint128 CityHash128WithSeed(const char *s, size_t len, uint128 seed) {
 }
 
 extern "C"
-uint128 CityHash128(char *s, size_t len) {
+uint128 CityHash128(const char *s, size_t len) {
   if (len >= 16) {
     return CityHash128WithSeed(s + 16,
                                len - 16,

--- a/clickhouse-rs-cityhash-sys/src/cc/city.h
+++ b/clickhouse-rs-cityhash-sys/src/cc/city.h
@@ -68,6 +68,7 @@ uint64 CityHash64WithSeeds(const char *buf, size_t len,
                            uint64 seed0, uint64 seed1);
 
 // Hash function for a byte array.
+extern "C"
 uint128 CityHash128(const char *s, size_t len);
 
 // Hash function for a byte array.  For convenience, a 128-bit seed is also


### PR DESCRIPTION
Some linkers cannot this, due to mix of extern C:

    : && /usr/bin/clang++-21 --target=x86_64-apple-darwin -fdiagnostics-color=always  -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -ffile-prefix-map=/ClickHouse=. -ftime-trace -falign-functions=64 -mbranches-within-32B-boundaries -ffp-contract=off  -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fPIC -Wall -Wextra -Wframe-larger-than=65536 -Weverything -Wpedantic -Wno-return-type-c-linkage -Wno-zero-length-array -Wno-c++98-compat-pedantic -Wno-c++20-compat -Wno-sign-conversion -Wno-deprecated-declarations -Wno-disabled-macro-expansion -Wno-documentation-unknown-command -Wno-double-promotion -Wno-exit-time-destructors -Wno-float-equal -Wno-global-constructors -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-padded -Wno-switch-enum -Wno-undefined-func-template -Wno-unused-template -Wno-weak-template-vtables -Wno-weak-vtables -Wno-thread-safety-negative -Wno-unsafe-buffer-usage -Wno-switch-default -Wno-nrvo -Wno-missing-noreturn -Wno-c2y-extensions -Wno-c23-extensions -O2 -g -DNDEBUG -O3 -g -fno-standalone-debug -gdwarf-aranges  -isysroot /ClickHouse/cmake/darwin/../toolchain/darwin-x86_64 -mmacosx-version-min=10.15 -Wl,-headerpad_max_install_names  --ld-path=/cctools/bin/x86_64-apple-darwin-ld -Wl,-U,_inside_main -u_zone_register @CMakeFiles/clickhouse.rsp -o programs/clickhouse && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-benchmark && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-check-marks && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-checksum-for-compressed-block && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-client && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse chc && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-compressor && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-disks && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-extract-from-config && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-format && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-git-import && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-local && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse chl && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse ch && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-obfuscator && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-server && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-static-files-disk-uploader && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-su && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-zookeeper-dump-tree && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-zookeeper-remove-by-list && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-keeper-data-dumper && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-keeper-utils && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-keeper-bench && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-keeper && cd /ClickHouse/ci/tmp/build/programs && mkdir -p /ClickHouse/ci/tmp/build/programs/..//lib/debug && touch /ClickHouse/ci/tmp/build/programs/..//lib/debug/clickhouse-keeper.debug && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-keeper-converter && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-keeper-client && cd /ClickHouse/ci/tmp/build/programs && mkdir -p /ClickHouse/ci/tmp/build/programs//lib/debug && touch /ClickHouse/ci/tmp/build/programs//lib/debug/clickhouse.debug && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse clickhouse-chdig && cd /ClickHouse/ci/tmp/build/programs && /usr/bin/cmake -E create_symlink clickhouse chdig
    Undefined symbols for architecture x86_64:
      "__Z11CityHash128PKcm", referenced from:
          __Z14CityHashCrc128PKcm in libchdig.a(e509d2bf2c02fe94-city.o)
    ld: symbol(s) not found for architecture x86_64
    clang++-21: error: linker command failed with exit code 1 (use -v to see invocation)
     enter the commit message for your changes. Lines starting