### PR TITLE
Fix INSERT hang/UnexpectedPacket on async_insert responses

### DIFF
--- a/src/binary/parser.rs
+++ b/src/binary/parser.rs
@@ -51,7 +51,10 @@ impl<'i, T: Read> Parser<'i, T> {
 
     fn parse_block(&mut self) -> Result<Packet<()>> {
         match self.info.timezone {
-            None => Err(Error::Driver(DriverError::UnexpectedPacket)),
+            None => Err(Error::Driver(DriverError::UnexpectedPacket {
+                packet: "Block",
+                context: "parse_block (timezone not yet received)",
+            })),
             Some(tz) => {
                 self.reader.skip_string()?;
                 let block = Block::load(&mut self.reader, tz, self.info.compress)?;

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -96,8 +96,13 @@ pub enum DriverError {
     #[error("Unknown packet 0x{:x}.", packet)]
     UnknownPacket { packet: u64 },
 
-    #[error("Unexpected packet.")]
-    UnexpectedPacket,
+    #[error("Unexpected packet `{packet}` at `{context}`.")]
+    UnexpectedPacket {
+        /// Human-readable packet variant name actually received.
+        packet: &'static str,
+        /// Call site that rejected it (e.g. `"read_block"`, `"hello"`).
+        context: &'static str,
+    },
 
     #[error("Timeout error.")]
     Timeout,

--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -119,7 +119,10 @@ impl ClickhouseTransport {
             }
         }
 
-        let mut transport = h.ok_or(Error::Driver(DriverError::UnexpectedPacket))?;
+        let mut transport = h.ok_or(Error::Driver(DriverError::UnexpectedPacket {
+            packet: "<none>",
+            context: "clear (expected Pong/Eof)",
+        }))?;
         transport.inconsistent = false;
         Ok(transport)
     }
@@ -310,9 +313,19 @@ impl PacketStream {
                 Ok(Packet::Eof(inner)) => h = Some(inner),
                 Ok(Packet::Block(block)) => b = Some(block),
                 Ok(Packet::Exception(e)) => return Err(Error::Server(e)),
-                Ok(Packet::TableColumns(_)) => (),
+                // Progress/ProfileInfo/TableColumns can show up at any point
+                // in a query or INSERT response (e.g. async_insert sends a
+                // zero-valued Progress before EndOfStream). Skip them.
+                Ok(Packet::TableColumns(_))
+                | Ok(Packet::ProfileInfo(_))
+                | Ok(Packet::Progress(_)) => (),
                 Err(e) => return Err(Error::Io(e)),
-                _ => return Err(Error::Driver(DriverError::UnexpectedPacket)),
+                Ok(other) => {
+                    return Err(Error::Driver(DriverError::UnexpectedPacket {
+                        packet: other.variant_name(),
+                        context: "read_block",
+                    }))
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,12 @@ impl ClientHandle {
                 }
                 Ok(Packet::Exception(e)) => return Err(Error::Server(e)),
                 Err(e) => return Err(Error::Io(e)),
-                _ => return Err(Error::Driver(DriverError::UnexpectedPacket)),
+                Ok(other) => {
+                    return Err(Error::Driver(DriverError::UnexpectedPacket {
+                        packet: other.variant_name(),
+                        context: "hello",
+                    }))
+                }
             }
         }
 
@@ -352,7 +357,12 @@ impl ClientHandle {
                         }
                         Ok(Packet::Exception(e)) => return Err(Error::Server(e)),
                         Err(e) => return Err(Error::Io(e)),
-                        _ => return Err(Error::Driver(DriverError::UnexpectedPacket)),
+                        Ok(other) => {
+                            return Err(Error::Driver(DriverError::UnexpectedPacket {
+                                packet: other.variant_name(),
+                                context: "ping",
+                            }))
+                        }
                     }
                 }
 
@@ -422,7 +432,12 @@ impl ClientHandle {
                                 | Ok(Packet::Progress(_)) => (),
                                 Ok(Packet::Exception(e)) => return Err(Error::Server(e)),
                                 Err(e) => return Err(Error::Io(e)),
-                                _ => return Err(Error::Driver(DriverError::UnexpectedPacket)),
+                                Ok(other) => {
+                                    return Err(Error::Driver(DriverError::UnexpectedPacket {
+                                        packet: other.variant_name(),
+                                        context: "execute",
+                                    }))
+                                }
                             }
                         }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -182,6 +182,20 @@ impl<S> Packet<S> {
             Packet::Eof(_) => Packet::Eof(transport.take().unwrap()),
         }
     }
+
+    /// Human-readable variant name, used by `DriverError::UnexpectedPacket`.
+    pub(crate) fn variant_name(&self) -> &'static str {
+        match self {
+            Packet::Hello(_, _) => "Hello",
+            Packet::Pong(_) => "Pong",
+            Packet::Progress(_) => "Progress",
+            Packet::ProfileInfo(_) => "ProfileInfo",
+            Packet::TableColumns(_) => "TableColumns",
+            Packet::Exception(_) => "Exception",
+            Packet::Block(_) => "Block",
+            Packet::Eof(_) => "Eof",
+        }
+    }
 }
 
 pub trait HasSqlType {

--- a/src/types/query_result/stream_blocks.rs
+++ b/src/types/query_result/stream_blocks.rs
@@ -116,7 +116,14 @@ impl<'a> Stream for BlockStream<'a> {
                         return Poll::Ready(Some(Ok(block)));
                     }
                 }
-                _ => return Poll::Ready(Some(Err(Error::Driver(DriverError::UnexpectedPacket)))),
+                other => {
+                    return Poll::Ready(Some(Err(Error::Driver(
+                        DriverError::UnexpectedPacket {
+                            packet: other.variant_name(),
+                            context: "stream_blocks",
+                        },
+                    ))))
+                }
             }
         }
     }


### PR DESCRIPTION
read_block only skipped TableColumns, so when the server sent Progress (e.g. the zero-valued Progress async_insert emits before EndOfStream) the insert failed with DriverError::UnexpectedPacket. Reproduced against pastila's ClickHouse Cloud backend: with a content/hash pair that passes the hash_is_correct constraint the server routes through async_insert queuing and sends Progress first — boom.

Also enrich DriverError::UnexpectedPacket with the actual packet variant and call-site context so future diagnostics pin the packet name and location rather than just "Unexpected packet."